### PR TITLE
ImportError: No module named argparse 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,5 +54,6 @@ setup(name='howdoi',
         },
       install_requires=[
         'pyquery',
+        'argparse',
         ],
       )


### PR DESCRIPTION
argparse was missing from the requirements. 
