### PR TITLE
Use `argparse.REMAINDER` to collect query arguments

### DIFF
--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -82,7 +82,7 @@ def howdoi(args):
 
 def command_line_runner():
     parser = argparse.ArgumentParser(description='code search tool')
-    parser.add_argument('query', metavar='QUERY', type=str, nargs='+',
+    parser.add_argument('query', metavar='QUERY', type=str, nargs=argparse.REMAINDER,
                         help='the question to answer')
     parser.add_argument('-p','--pos', help='select answer in specified position (default: 1)', default=1)
     parser.add_argument('-a','--all', help='display the full text of the answer',


### PR DESCRIPTION
Essentially, it prevents argparse from parsing arguments after the first positional argument (the query in this case).

Use Case:

```
$ howdoi undo rm -rf
git reset HEAD@{1}
```

Pre-patch error:

```
$ howdoi undo rm -rf
usage: howdoi [-h] [-p POS] [-a] [-l] QUERY [QUERY ...]
howdoi: error: unrecognized arguments: -rf
```
