### PR TITLE
Changed chmod instruction to -R (recursive), in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,6 +113,6 @@ If so, just do this:
 
 ::
 
-    sudo chmod go+w /Library/Python/2.7/site-packages/
+    sudo chmod -R go+w /Library/Python/2.7/site-packages/
 
 `From this discussion <https://github.com/gleitz/howdoi/issues/10>`_


### PR DESCRIPTION
`easy-install.pth` in site-packages needs correct permissions set too, easiest way is to just recursively change the whole dir.
