### PR TITLE
Added Colors with attempted determination of language using the query

### DIFF
--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -14,6 +14,9 @@ import sys
 import json
 import argparse
 import re
+import pygments
+import pygments.lexers
+import pygments.formatters
 
 from pyquery import PyQuery as pq
 
@@ -75,10 +78,27 @@ def get_instructions(args):
         return ''
     return text
 
+def color(instructions,lexer):
+    formatter = pygments.formatters.TerminalFormatter()
+    return pygments.highlight(instructions, lexer, formatter)
+
+def find_lexer(query,text):
+    query = query.lower()
+    for lexer in pygments.lexers.get_all_lexers():
+        if query.find(lexer[0].lower()) != -1:
+            return pygments.lexers.get_lexer_by_name(lexer[1][0])
+    return pygments.lexers.guess_lexer(text)
+
 def howdoi(args):
     args['query'] = ' '.join(args['query']).replace('?', '')
     instructions = get_instructions(args) or 'Sorry, couldn\'t find any help with that topic'
-    print instructions
+
+    if not args['color']:
+        print instructions
+    else:
+        lexer = find_lexer(args['query'],instructions)
+        print lexer
+        print color(instructions,lexer)
 
 def command_line_runner():
     parser = argparse.ArgumentParser(description='code search tool')
@@ -86,6 +106,8 @@ def command_line_runner():
                         help='the question to answer')
     parser.add_argument('-p','--pos', help='select answer in specified position (default: 1)', default=1)
     parser.add_argument('-a','--all', help='display the full text of the answer',
+                        action='store_true')
+    parser.add_argument('-c','--color', help='show the answer in color',
                         action='store_true')
     parser.add_argument('-l','--link', help='display only the answer link',
                         action='store_true')

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ lxml==3.0.1
 pyquery==1.2.2
 wsgiref==0.1.2
 argparse
+pygments==1.5


### PR DESCRIPTION
As I have it now, it tries to guess the language using the words in the query, then uses analyse_text to see if its a good fit. Otherwise it uses the guess function built into pygmentys. I'm probably going to change this to use the stackoverflow tags as the criteria because it seems to choke on things like "ruby http request" because both 'ruby' and 'http' are syntaxes that pygments can parse.
