### PR TITLE
Optionally Display the question along with the answers

### DIFF
--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -78,6 +78,9 @@ def get_instructions(args):
         text = instructions.eq(0).text()
     if not text:
         return ''
+    if args['title']:
+        title = html('title').eq(0).text()
+        return '\n'.join((title, text))
     return text
 
 


### PR DESCRIPTION
These two commits add a new option,

```
--title
```

which will display the title of the question.

I simply grab the HTML title for the question.  We could optionally parse for ".question-hyperlink" instead, if we did not want to include the site the query came from.  I can make that change if desired!

I use '\n'.join rather than text = title + '\n' + text.  From my understanding, this is supposed to be faster!

This commit adds no new PEP8 or pylint warnings/errors.

We do not provide an 'else' clause, since we are performing an early return in this case.
