### PR TITLE
Add default answer in case there is no answer in the SO question.

### DIFF
--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -30,6 +30,7 @@ USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/537.17 
 ANSWER_HEADER = u'--- Answer {0} ---\n{1}'
 NO_ANSWER_MSG = '< no answer given >'
 
+
 def get_result(url):
     return requests.get(url, headers={'User-Agent': USER_AGENT}).text
 


### PR DESCRIPTION
There are cases, e.g. `howdoi -n3 run an http server in python`, where there are
answers in the search results which are empty (e.g. there's a SO question, but
it has no answers). Currently, howdoi crashes on these. Ideally, I should
probably check to see if a link has an answer, and toss out those which do not.
This is a little fix though, and prevents the program from crashing.
