### PR TITLE
Changed  arparse arguement parser with Docopt

### DIFF
--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -164,7 +164,7 @@ def get_instructions(args):
         return ''
     answers = []
     append_header = args['num_answers'] > 1
-    initial_position = int(args['pos'])
+    initial_position = args['pos']
     for answer_number in range(args['num_answers']):
         current_position = answer_number + initial_position
         args['pos'] = current_position

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-docopt=0.6.1
+docopt==0.6.1
 cssselect==0.7.1
 lxml==3.0.1
 pyquery==1.2.4

--- a/test_howdoi.py
+++ b/test_howdoi.py
@@ -11,7 +11,6 @@ class HowdoiTestCase(unittest.TestCase):
     
     def call_howdoi(self, query):
         args = howdoi.parse_args(query.split(' ')) 
-        print args
         return howdoi.howdoi(args)
 
     def setUp(self):


### PR DESCRIPTION
The argument parser used was Argparse,
this is replaced with Docopt arguement parser.

Docopt:http://docopt.org

Docopt(it uses only re and sys)  is  a beautiful pythonic argument parser. It allows Docstrings written as help
message to be used as template to parse arguments.

Howdoi is starting to extend and include more options,so this will be easier
on the eye and brain.
