### PR TITLE
Enable testing on Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "2.7"
   - "3.2"
   - "3.3"
+  - "3.4"
 # command to install dependencies
 install: "pip install -r requirements.txt --use-mirrors"
 # command to run tests


### PR DESCRIPTION
As per [this Travis CI blog post](http://blog.travis-ci.com/2014-04-28-upcoming-build-environment-updates/), testing on Python 3.4 is now supported.
