### PR TITLE
Enable Python 3.4 classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.2",
         "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.4",
         "Topic :: Documentation",
     ],
     keywords='howdoi help console command line answer',


### PR DESCRIPTION
Since #87 was merged, we can enable the Python 3.4 classifier
