### PR TITLE
Add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3-onbuild
+MAINTAINER emile@vauge.com
+
+ADD . /howdoi
+WORKDIR /howdoi
+
+RUN python setup.py install
+
+ENTRYPOINT [ "howdoi" ]
+CMD [ "-h" ]

--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,18 @@ or
 
     python setup.py install
 
+or
+
+::
+
+    docker build -t howdoi .
+
+or
+
+::
+
+   docker pull emilevauge/howdoi
+
 Usage
 -----
 
@@ -104,6 +116,11 @@ Usage
       -C, --clear-cache     clear the cache
       -v, --version         displays the current version of howdoi
 
+or using Docker
+
+::
+
+    docker run -it --rm howdoi
 
 Author
 ------


### PR DESCRIPTION
Hi

I thought it would be nice to have a Docker image of Howdoi. This allows users who don't have python installed to use this utility anyway.

Emile