### PR TITLE
Fix issue where the wrong answer url was being displayed to the user

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -121,7 +121,7 @@ Development
 -----------
 
 -  Checkout the repo
--  Run `python -m howdoi.howdoi QUERY` (if you try running `python howdoi/howdoi.py` you my get `ValueError: Attempted relative import in non-package`).
+-  Run ``python -m howdoi.howdoi QUERY`` (if you try running ``python howdoi/howdoi.py`` you might get ``ValueError: Attempted relative import in non-package``).
 
 
 Troubleshooting

--- a/README.rst
+++ b/README.rst
@@ -97,8 +97,20 @@ Usage
                             number of answers to return
       -C, --clear-cache     clear the cache
       -v, --version         displays the current version of howdoi
+      
+      
+As a shortcut, if you commonly use the same paremeters each time and don't want to type them, add something similar to your .bash_profile (or otherwise). This example gives you 5 colored results each time.
 
+::
 
+    alias h='function hdi(){ howdoi $* -c -n 5; }; hdi'
+
+And then to run it from the command line simply type:
+
+::
+
+    $h this is my query for howdoi
+    
 Author
 ------
 

--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -60,7 +60,8 @@ USER_AGENTS = ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:11.0) Gecko/2010
                 'Chrome/19.0.1084.46 Safari/536.5'),
                ('Mozilla/5.0 (Windows; Windows NT 6.1) AppleWebKit/536.5 (KHTML, like Gecko) Chrome/19.0.1084.46'
                 'Safari/536.5'), )
-ANSWER_HEADER = u('--- Answer {0} ---\n{1}')
+STAR_HEADER = u('\u2605')
+ANSWER_HEADER = u('{2}  {0} {2}\n{1}')
 NO_ANSWER_MSG = '< no answer given >'
 XDG_CACHE_DIR = os.environ.get('XDG_CACHE_HOME',
                                os.path.join(os.path.expanduser('~'), '.cache'))
@@ -158,6 +159,7 @@ def _get_answer(args, links):
     args['tags'] = [t.text for t in html('.post-tag')]
 
     if not instructions and not args['all']:
+        texts = []
         text = first_answer.find('.post-text').eq(0).text()
     elif args['all']:
         texts = []
@@ -168,7 +170,7 @@ def _get_answer(args, links):
                     texts.append(_format_output(current_text, args))
                 else:
                     texts.append(current_text)
-        texts.append('\n---\nAnswer from {0}'.format(link))
+        texts.append('\n---\n'.format(link))
         text = '\n'.join(texts)
     else:
         text = _format_output(instructions.eq(0).text(), args)
@@ -181,19 +183,21 @@ def _get_answer(args, links):
 def _get_instructions(args):
     links = _get_links(args['query'])
 
+    only_hyperlinks = args.get('link')
+
     if not links:
         return False
     answers = []
-    append_header = args['num_answers'] > 1
     initial_position = args['pos']
     for answer_number in range(args['num_answers']):
         current_position = answer_number + initial_position
         args['pos'] = current_position
+        link = get_link_at_pos(links, current_position)
         answer = _get_answer(args, links)
         if not answer:
             continue
-        if append_header:
-            answer = ANSWER_HEADER.format(current_position, answer)
+        if not only_hyperlinks:
+            answer = ANSWER_HEADER.format(link, answer, STAR_HEADER)
         answer += '\n'
         answers.append(answer)
     return '\n'.join(answers)

--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -183,6 +183,7 @@ def _get_instructions(args):
     links = _get_links(args['query'])
 
     only_hyperlinks = args.get('link')
+    star_headers = (args['num_answers'] > 1 or args['all'])
 
     if not links:
         return False
@@ -196,11 +197,16 @@ def _get_instructions(args):
         if not answer:
             continue
         if not only_hyperlinks:
-            answer = ANSWER_HEADER.format(link, answer, STAR_HEADER)
+            answer = format_answer(link, answer, star_headers)
         answer += '\n'
         answers.append(answer)
     return '\n'.join(answers)
 
+def format_answer(link, answer, star_headers):
+    if star_headers:
+        return ANSWER_HEADER.format(link, answer, STAR_HEADER)
+    else:
+        return answer
 
 def _enable_cache():
     if not os.path.exists(CACHE_DIR):

--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -159,7 +159,6 @@ def _get_answer(args, links):
     args['tags'] = [t.text for t in html('.post-tag')]
 
     if not instructions and not args['all']:
-        texts = []
         text = first_answer.find('.post-text').eq(0).text()
     elif args['all']:
         texts = []

--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -145,7 +145,6 @@ def _get_questions(links):
 
 
 def _get_answer(args, links):
-    links = _get_questions(links)
     link = get_link_at_pos(links, args['pos'])
     if not link:
         return False
@@ -180,6 +179,7 @@ def _get_answer(args, links):
 
 def _get_instructions(args):
     links = _get_links(args['query'])
+    question_links = _get_questions(links)
 
     only_hyperlinks = args.get('link')
     star_headers = (args['num_answers'] > 1 or args['all'])
@@ -191,8 +191,8 @@ def _get_instructions(args):
     for answer_number in range(args['num_answers']):
         current_position = answer_number + initial_position
         args['pos'] = current_position
-        link = get_link_at_pos(links, current_position)
-        answer = _get_answer(args, links)
+        link = get_link_at_pos(question_links, current_position)
+        answer = _get_answer(args, question_links)
         if not answer:
             continue
         if not only_hyperlinks:

--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -61,7 +61,7 @@ USER_AGENTS = ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:11.0) Gecko/2010
                ('Mozilla/5.0 (Windows; Windows NT 6.1) AppleWebKit/536.5 (KHTML, like Gecko) Chrome/19.0.1084.46'
                 'Safari/536.5'), )
 STAR_HEADER = u('\u2605')
-ANSWER_HEADER = u('{2}  {0} {2}\n{1}')
+ANSWER_HEADER = u('{2}  Answer from {0} {2}\n{1}')
 NO_ANSWER_MSG = '< no answer given >'
 XDG_CACHE_DIR = os.environ.get('XDG_CACHE_HOME',
                                os.path.join(os.path.expanduser('~'), '.cache'))
@@ -170,7 +170,6 @@ def _get_answer(args, links):
                     texts.append(_format_output(current_text, args))
                 else:
                     texts.append(current_text)
-        texts.append('\n---\n'.format(link))
         text = '\n'.join(texts)
     else:
         text = _format_output(instructions.eq(0).text(), args)

--- a/test_howdoi.py
+++ b/test_howdoi.py
@@ -66,7 +66,7 @@ class HowdoiTestCase(unittest.TestCase):
         first_answer = self.call_howdoi(query)
         second_answer = self.call_howdoi(query + ' -a')
         self.assertNotEqual(first_answer, second_answer)
-        self.assertNotEqual(re.match('.*Answer from http.?://stackoverflow.com.*', second_answer, re.DOTALL), None)
+        self.assertNotEqual(re.match('.*http.?://.*', second_answer, re.DOTALL), None)
 
     def test_multiple_answers(self):
         query = self.queries[0]

--- a/test_howdoi.py
+++ b/test_howdoi.py
@@ -66,7 +66,7 @@ class HowdoiTestCase(unittest.TestCase):
         first_answer = self.call_howdoi(query)
         second_answer = self.call_howdoi(query + ' -a')
         self.assertNotEqual(first_answer, second_answer)
-        self.assertNotEqual(re.match('.*http.?://.*', second_answer, re.DOTALL), None)
+        self.assertNotEqual(re.match('.*Answer from http.?://.*', second_answer, re.DOTALL), None)
 
     def test_multiple_answers(self):
         query = self.queries[0]

--- a/test_howdoi.py
+++ b/test_howdoi.py
@@ -4,6 +4,7 @@
 import os
 import unittest
 import re
+import sys
 
 from howdoi import howdoi
 
@@ -19,7 +20,8 @@ class HowdoiTestCase(unittest.TestCase):
         self.queries = ['format date bash',
                         'print stack trace python',
                         'convert mp4 to animated gif',
-                        'create tar archive']
+                        'create tar archive',
+                        'cat']
         self.pt_queries = ['abrir arquivo em python',
                            'enviar email em django',
                            'hello world em c']
@@ -51,9 +53,15 @@ class HowdoiTestCase(unittest.TestCase):
         for query in self.pt_queries:
             self.assertTrue(self.call_howdoi(query))
 
-    def test_answer_links(self):
+    def test_answer_links_using_l_option(self):
         for query in self.queries:
-            self.assertNotEqual(re.match('http.?://.*', self.call_howdoi(query + ' -l'), re.DOTALL), None)
+            response = self.call_howdoi(query + ' -l')
+            self.assertNotEqual(re.match('http.?://.*questions/\d.*', response, re.DOTALL), None)
+
+    def test_answer_links_using_all_option(self):
+        for query in self.queries:
+            response = self.call_howdoi(query + ' -a')
+            self.assertNotEqual(re.match('.*http.?://.*questions/\d.*', response, re.DOTALL), None)
 
     def test_position(self):
         query = self.queries[0]
@@ -87,6 +95,15 @@ class HowdoiTestCase(unittest.TestCase):
         self.assertTrue(normal.find('[39;') is -1)
         self.assertTrue(colorized.find('[39;') is not -1)
 
+    def test_get_questions(self):
+        links = ['https://stackoverflow.com/questions/tagged/cat', 'http://rads.stackoverflow.com/amzn/click/B007KAZ166', 'https://stackoverflow.com/questions/40108569/how-to-get-the-last-line-of-a-file-using-cat-command']
+        expected_output = ['https://stackoverflow.com/questions/40108569/how-to-get-the-last-line-of-a-file-using-cat-command']
+        actual_output = howdoi._get_questions(links)
+        if sys.version < '2.7':
+            self.assertEqual(len(actual_output), len(expected_output))
+            self.assertEqual(sorted(actual_output), sorted(expected_output))
+        else:
+            self.assertSequenceEqual(actual_output, expected_output)
 
 class HowdoiTestCaseEnvProxies(unittest.TestCase):
 


### PR DESCRIPTION
Issue was originally reported in #175. Since we're dependent on ```_get_questions``` to extract the question URLs from the list of all URLs, I wrote an automated test for that specific function as well.