### PR TITLE
Fix issue where the wrong answer url was being displayed to the user

### DIFF
--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -145,7 +145,6 @@ def _get_questions(links):
 
 
 def _get_answer(args, links):
-    links = _get_questions(links)
     link = get_link_at_pos(links, args['pos'])
     if not link:
         return False
@@ -180,6 +179,7 @@ def _get_answer(args, links):
 
 def _get_instructions(args):
     links = _get_links(args['query'])
+    question_links = _get_questions(links)
 
     only_hyperlinks = args.get('link')
     star_headers = (args['num_answers'] > 1 or args['all'])
@@ -191,8 +191,8 @@ def _get_instructions(args):
     for answer_number in range(args['num_answers']):
         current_position = answer_number + initial_position
         args['pos'] = current_position
-        link = get_link_at_pos(links, current_position)
-        answer = _get_answer(args, links)
+        link = get_link_at_pos(question_links, current_position)
+        answer = _get_answer(args, question_links)
         if not answer:
             continue
         if not only_hyperlinks:


### PR DESCRIPTION
Also added an automated test to check if _get_questions is working.
Ensured that this automated test works on Python 2.6 as well.

Issue was originally reported in #175, and fixed in #176, but a problem with rebasing forced me to abandon the PR and start a new "clean" PR. This time, everything's good to go. 👍