### PR TITLE
Add support for bing search engine

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,7 @@ Usage
 
 ::
 
-    usage: howdoi.py [-h] [-p POS] [-a] [-l] [-c] [-n NUM_ANSWERS] [-C] [-v] QUERY [QUERY ...]
+    usage: howdoi.py [-h] [-p POS] [-a] [-l] [-c] [-b] [-n NUM_ANSWERS] [-C] [-v] QUERY [QUERY ...]
 
     instant coding answers via the command line
 

--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,7 @@ Usage
 
 ::
 
-    usage: howdoi.py [-h] [-p POS] [-a] [-l] [-c] [-b] [-n NUM_ANSWERS] [-C] [-v] QUERY [QUERY ...]
+    usage: howdoi.py [-h] [-p POS] [-a] [-l] [-c] [-n NUM_ANSWERS] [-C] [-v] QUERY [QUERY ...]
 
     instant coding answers via the command line
 
@@ -97,7 +97,6 @@ Usage
                             number of answers to return
       -C, --clear-cache     clear the cache
       -v, --version         displays the current version of howdoi
-      -b, --bing            using bing search engine rather than google
       
       
 As a shortcut, if you commonly use the same paremeters each time and don't want to type them, add something similar to your .bash_profile (or otherwise). This example gives you 5 colored results each time.
@@ -121,6 +120,7 @@ Author
 Notes
 -----
 
+-  You can set the HOWDOI_USING_BING environment variable to fetch stackoverflow links from Bing, this variable is useful for users who can't access google.
 -  Works with Python2 and Python3
 -  A standalone Windows executable with the howdoi application `is available here <https://dl.dropbox.com/u/101688/website/misc/howdoi.exe>`_.
 -  An Alfred Workflow for howdoi can be found at `http://blog.gleitzman.com/post/48539944559/howdoi-alfred-even-more-instant-answers <http://blog.gleitzman.com/post/48539944559/howdoi-alfred-even-more-instant-answers>`_.

--- a/README.rst
+++ b/README.rst
@@ -97,6 +97,7 @@ Usage
                             number of answers to return
       -C, --clear-cache     clear the cache
       -v, --version         displays the current version of howdoi
+      -b, --bing            using bing search engine rather than google
       
       
 As a shortcut, if you commonly use the same paremeters each time and don't want to type them, add something similar to your .bash_profile (or otherwise). This example gives you 5 colored results each time.

--- a/README.rst
+++ b/README.rst
@@ -120,7 +120,7 @@ Author
 Notes
 -----
 
--  You can set the HOWDOI_USING_BING environment variable to fetch stackoverflow links from Bing, this variable is useful for users who can't access google.
+-  You can set the HOWDOI_SEARCH_ENGINE environment variable to change the search engines to find StackOverflow links (default: google).  Other options for now include `bing`.
 -  Works with Python2 and Python3
 -  A standalone Windows executable with the howdoi application `is available here <https://dl.dropbox.com/u/101688/website/misc/howdoi.exe>`_.
 -  An Alfred Workflow for howdoi can be found at `http://blog.gleitzman.com/post/48539944559/howdoi-alfred-even-more-instant-answers <http://blog.gleitzman.com/post/48539944559/howdoi-alfred-even-more-instant-answers>`_.

--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -16,7 +16,7 @@ import re
 import requests
 import requests_cache
 import sys
-from . import __version__
+#from . import __version__
 
 from pygments import highlight
 from pygments.lexers import guess_lexer, get_lexer_by_name
@@ -95,14 +95,6 @@ def _get_result(url):
         print('[ERROR] Encountered an SSL Error. Try using HTTP instead of '
               'HTTPS by setting the environment variable "HOWDOI_DISABLE_SSL".\n')
         raise e
-
-
-def _get_search_url(engine):
-    support_engine_url = {
-        'bing': 'www.bing.com/search?q=site:{0}%20{1}',
-        'google': 'www.google.com/search?q=site:{0}%20{1}'
-    }
-    return SCHEME + support_engine_url[engine]
 
 
 def _generate_links_of_bing(html):

--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -51,11 +51,6 @@ else:
     SCHEME = 'https://'
     VERIFY_SSL_CERTIFICATE = True
 
-if os.getenv('HOWDOI_USING_BING'):
-    SEARCH_URL = SCHEME + 'www.bing.com/search?q=site:{0}%20{1}'
-else:
-    SEARCH_URL = SCHEME + 'www.google.com/search?q=site:{0}%20{1}'
-
 URL = os.getenv('HOWDOI_URL') or 'stackoverflow.com'
 
 USER_AGENTS = ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:11.0) Gecko/20100101 Firefox/11.0',
@@ -107,17 +102,31 @@ def _generate_links_of_google(html):
         [a.attrib['href'] for a in html('.r')('a')]
 
 
-def _generate_links(html):
-    if os.getenv('HOWDOI_USING_BING'):
+def _generate_links(html, search_engine):
+    if search_engine == 'bing':
         return _generate_links_of_bing(html)
-    else:
+    elif search_engine == 'google':
         return _generate_links_of_google(html)
 
 
+def _dispatch_url(search_engine):
+    known_engines = {
+        'bing': SCHEME + 'www.bing.com/search?q=site:{0}%20{1}',
+        'google': SCHEME + 'www.google.com/search?q=site:{0}%20{1}'
+    }
+    return known_engines.get(search_engine, None)
+
+
 def _get_links(query):
-    result = _get_result(SEARCH_URL.format(URL, url_quote(query)))
+    search_engine = os.getenv('HOWDOI_SEARCH_ENGINE', 'google')
+    search_url = _dispatch_url(search_engine)
+
+    if search_url is None:
+        return None
+
+    result = _get_result(search_url.format(URL, url_quote(query)))
     html = pq(result)
-    return _generate_links(html)
+    return _generate_links(html, search_engine)
 
 
 def get_link_at_pos(links, position):
@@ -200,13 +209,14 @@ def _get_answer(args, links):
 
 def _get_instructions(args):
     links = _get_links(args['query'])
+    if not links:
+        return False
+
     question_links = _get_questions(links)
 
     only_hyperlinks = args.get('link')
     star_headers = (args['num_answers'] > 1 or args['all'])
 
-    if not links:
-        return False
     answers = []
     initial_position = args['pos']
     for answer_number in range(args['num_answers']):

--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -16,7 +16,7 @@ import re
 import requests
 import requests_cache
 import sys
-#from . import __version__
+from . import __version__
 
 from pygments import highlight
 from pygments.lexers import guess_lexer, get_lexer_by_name

--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -104,11 +104,8 @@ def _get_links_on_bing(query):
     SEARCH_ENGINE = 'bing'
 
     result = _get_result(_get_search_url(SEARCH_ENGINE).format(URL, url_quote(query)))
-    with open('test.html') as f:
-        result = f.read()
     html = pq(result)
     html.remove_namespaces()
-    print(html('a'))
     return [a.attrib['href'] for a in html('.b_algo')('h2')('a')]
 
 


### PR DESCRIPTION
Sadly found that howdoi doesn't work for me, after hacking into the code, I found that howdoi use *Google* to search for relative links of *StackOverflow*, but *Google* search engine doesn't support for my country :(

So I would like to add support for *Bing* search engine.  To make it work in my environment.

When user input command like this:
    howdoi usage of tar -b
Howdoi will use bing search engine to find stackoverflow links, and then user can get the result here :)

Consider for add an argument rather than use environment variable:
   I think that use argument for bing searching can make user easily select when to use bing or google, if using environment variable, it's a little more complicated.

And by the way, I have add 2 blank line to make our code more fitted with pep8