### PR TITLE
use requests session to improve performance for querying more than 1 answer

### DIFF
--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -72,6 +72,7 @@ XDG_CACHE_DIR = os.environ.get('XDG_CACHE_HOME',
 CACHE_DIR = os.path.join(XDG_CACHE_DIR, 'howdoi')
 CACHE_FILE = os.path.join(CACHE_DIR, 'cache{0}'.format(
     sys.version_info[0] if sys.version_info[0] == 3 else ''))
+howdoi_session = requests.session()
 
 
 def get_proxies():
@@ -88,8 +89,8 @@ def get_proxies():
 
 def _get_result(url):
     try:
-        return requests.get(url, headers={'User-Agent': random.choice(USER_AGENTS)}, proxies=get_proxies(),
-                            verify=VERIFY_SSL_CERTIFICATE).text
+        return howdoi_session.get(url, headers={'User-Agent': random.choice(USER_AGENTS)}, proxies=get_proxies(),
+                                  verify=VERIFY_SSL_CERTIFICATE).text
     except requests.exceptions.SSLError as e:
         print('[ERROR] Encountered an SSL Error. Try using HTTP instead of '
               'HTTPS by setting the environment variable "HOWDOI_DISABLE_SSL".\n')
@@ -305,6 +306,8 @@ def command_line_runner():
     else:
         # Write UTF-8 to stdout: https://stackoverflow.com/a/3603160
         sys.stdout.buffer.write(utf8_result)
+    # close the session to release connection
+    howdoi_session.close()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I found that when I'm trying to use howdoi like this:
```
howdoi python asyncio sample -n 4 
```
which takes me a little long time to get the response.  So I'm trying to make it to be more efficient when howdoi try to fetch more than one answers.  Which use `get` method defined in ``` requests Session ``` object instead of using ``` requests.get ``` function to fetch page.

The benefit of using session is showed here:
http://docs.python-requests.org/en/master/user/advanced/ 

There are another way to rewrite this like using python3 *asyncio* library, to make all these fetch action *asynchronous*.  But each running of howdoi will not make very large connections, and so the benefit of using *asyncio* library is not so obvious.  And using *asyncio* library will break *python2* support...

Here are my running time test for using `requests session` and the origin `requests.get` function.
Each of them take the following howdoi command (my environment have a little poor performance)

1. Using `requests.get` function
```$ time python howdoi.py python async samples -n 5```
....omit output from howdoi....
real	0m33.787s
user	0m0.668s
sys	0m0.116s

2. Using `get` method which is defined in `requests.Session` object
```$ time python howdoi.py javascript promise api samples -n 5```
....omit output from howdoi....
real	0m13.920s
user	0m0.520s
sys	0m0.048s

So I think using `requests.Session` object to fetch page can save our time to get results (When we need more than one answer)
