### PR TITLE
add '=' split string between answers to make the result shows more friendly

### DIFF
--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -218,6 +218,8 @@ def _get_instructions(args):
 
     answers = []
     initial_position = args['pos']
+    answer_spliter = '\n' + '=' * 80 + '\n\n'
+    
     for answer_number in range(args['num_answers']):
         current_position = answer_number + initial_position
         args['pos'] = current_position
@@ -229,7 +231,7 @@ def _get_instructions(args):
             answer = format_answer(link, answer, star_headers)
         answer += '\n'
         answers.append(answer)
-    return '\n'.join(answers)
+    return answer_spliter.join(answers)
 
 
 def format_answer(link, answer, star_headers):

--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -218,7 +218,8 @@ def _get_instructions(args):
 
     answers = []
     initial_position = args['pos']
-    answer_spliter = '\n' + '=' * 80 + '\n\n'
+    spliter_length = 80
+    answer_spliter = '\n' + '=' * spliter_length + '\n\n'
     
     for answer_number in range(args['num_answers']):
         current_position = answer_number + initial_position


### PR DESCRIPTION
Hi, I found that *howdoi* shows a little unfriendly when we are try to query for more than one answers, when we Read *howdoi* output, it's a little hard to figure out where is the answer 1st, where is the answer 2nd immediately (it's especially when we read the output from console).

So I would like to add spliters (using '=') between answers.  Of cause it's not so necessary for the howdoi main feature...

**Before adding split line between answer**:
```
★  Answer from https://stackoverflow.com/questions/37329392/does-a-long-running-loop-with-async-io-needs-the-longrunning-option ★
Short answer, no. For background reading try http://blog.stephencleary.com/2013/11/there-is-no-thread.html
Also, you do not need the await Task.Delay at the end to give time for other work in an async-await scenario.
Regarding the longrunning option see https://social.msdn.microsoft.com/Forums/en-US/8304b44f-0480-488c-93a4-ec419327183b/when-should-a-taks-be-considered-longrunning?forum=parallelextensions

★  Answer from https://stackoverflow.com/questions/21072205/async-all-the-way-down-issue ★
Yes. There is a penalty (though not a huge one), and if you don't need to be async don't be. This pattern is often called "return await" where you can almost always remove both the async and the await . Simply return the task you already have that represents the asynchronous operations:
private Task C_Async(int id)
{
    // This method executes very fast
    var idTemp = paddID(id);
    return D_Async(idTemp);
}

private Task D_Async(string id)
{
    // This method executes very fast
    return E_Async(id);
}

In this specific case Index will only await the tasks that E_Async returns. That means that after all the I/O is done the next line of code will directly be return View(); . C_Async and D_Async already ran and finished in the synchronous call.

★  Answer from https://stackoverflow.com/questions/10806951/how-to-limit-the-amount-of-concurrent-async-i-o-operations ★
You can definitely do this in the latest versions of async for .NET, using .NET 4.5 Beta. The previous post from 'usr' points to a good article written by Stephen Toub, but the less announced news is that the async semaphore actually made it into the Beta release of .NET 4.5
If you look at our beloved SemaphoreSlim class (which you should be using since it's more performant than the original Semaphore ), it now boasts the WaitAsync(...) series of overloads, with all of the expected arguments - timeout intervals, cancellation tokens, all of your usual scheduling friends :)
Stephen's also written a more recent blog post about the new .NET 4.5 goodies that came out with beta see What’s New for Parallelism in .NET 4.5 Beta .
Last, here's some sample code about how to use SemaphoreSlim for async method throttling:
public async Task MyOuterMethod()
{
    // let's say there is a list of 1000+ URLs
    var urls = { "http://google.com", "http://yahoo.com", ... };

    // now let's send HTTP requests to each of these URLs in parallel
    var allTasks = new List<Task>();
    var throttler = new SemaphoreSlim(initialCount: 20);
    foreach (var url in urls)
    {
        // do an async wait until we can schedule again
        await throttler.WaitAsync();

        // using Task.Run(...) to run the lambda in its own parallel
        // flow on the threadpool
        allTasks.Add(
            Task.Run(async () =>
            {
                try
                {
                    var client = new HttpClient();
                    var html = await client.GetStringAsync(url);
                }
                finally
                {
                    throttler.Release();
                }
            }));
    }

    // won't get here until all urls have been put into tasks
    await Task.WhenAll(allTasks);

    // won't get here until all tasks have completed in some way
    // (either success or exception)
}

Last, but probably a worthy mention is a solution that uses TPL-based scheduling. You can create delegate-bound tasks on the TPL that have not yet been started, and allow for a custom task scheduler to limit the concurrency. In fact, there's an MSDN sample for it here:
See also TaskScheduler .
```

**After adding split line between answer**:
```
★  Answer from https://stackoverflow.com/questions/37329392/does-a-long-running-loop-with-async-io-needs-the-longrunning-option ★
Short answer, no. For background reading try http://blog.stephencleary.com/2013/11/there-is-no-thread.html
Also, you do not need the await Task.Delay at the end to give time for other work in an async-await scenario.
Regarding the longrunning option see https://social.msdn.microsoft.com/Forums/en-US/8304b44f-0480-488c-93a4-ec419327183b/when-should-a-taks-be-considered-longrunning?forum=parallelextensions

================================================================================

★  Answer from https://stackoverflow.com/questions/21072205/async-all-the-way-down-issue ★
Yes. There is a penalty (though not a huge one), and if you don't need to be async don't be. This pattern is often called "return await" where you can almost always remove both the async and the await . Simply return the task you already have that represents the asynchronous operations:
private Task C_Async(int id)
{
    // This method executes very fast
    var idTemp = paddID(id);
    return D_Async(idTemp);
}

private Task D_Async(string id)
{
    // This method executes very fast
    return E_Async(id);
}

In this specific case Index will only await the tasks that E_Async returns. That means that after all the I/O is done the next line of code will directly be return View(); . C_Async and D_Async already ran and finished in the synchronous call.

================================================================================

★  Answer from https://stackoverflow.com/questions/10806951/how-to-limit-the-amount-of-concurrent-async-i-o-operations ★
You can definitely do this in the latest versions of async for .NET, using .NET 4.5 Beta. The previous post from 'usr' points to a good article written by Stephen Toub, but the less announced news is that the async semaphore actually made it into the Beta release of .NET 4.5
If you look at our beloved SemaphoreSlim class (which you should be using since it's more performant than the original Semaphore ), it now boasts the WaitAsync(...) series of overloads, with all of the expected arguments - timeout intervals, cancellation tokens, all of your usual scheduling friends :)
Stephen's also written a more recent blog post about the new .NET 4.5 goodies that came out with beta see What’s New for Parallelism in .NET 4.5 Beta .
Last, here's some sample code about how to use SemaphoreSlim for async method throttling:
public async Task MyOuterMethod()
{
    // let's say there is a list of 1000+ URLs
    var urls = { "http://google.com", "http://yahoo.com", ... };

    // now let's send HTTP requests to each of these URLs in parallel
    var allTasks = new List<Task>();
    var throttler = new SemaphoreSlim(initialCount: 20);
    foreach (var url in urls)
    {
        // do an async wait until we can schedule again
        await throttler.WaitAsync();

        // using Task.Run(...) to run the lambda in its own parallel
        // flow on the threadpool
        allTasks.Add(
            Task.Run(async () =>
            {
                try
                {
                    var client = new HttpClient();
                    var html = await client.GetStringAsync(url);
                }
                finally
                {
                    throttler.Release();
                }
            }));
    }

    // won't get here until all urls have been put into tasks
    await Task.WhenAll(allTasks);

    // won't get here until all tasks have completed in some way
    // (either success or exception)
}

Last, but probably a worthy mention is a solution that uses TPL-based scheduling. You can create delegate-bound tasks on the TPL that have not yet been started, and allow for a custom task scheduler to limit the concurrency. In fact, there's an MSDN sample for it here:
See also TaskScheduler .
```