### PR TITLE
Update pyquery dependency

### DIFF
--- a/howdoi.rb
+++ b/howdoi.rb
@@ -31,8 +31,8 @@ class Howdoi < Formula
 	end
 
   resource "pyquery" do
-		url "https://pypi.python.org/packages/e6/77/05b500811e360e53a254ca1f452e1e2f38b5284367e1172867b921d8020d/pyquery-1.2.11.tar.gz"
-		sha256 "4a832ba73bfba03486f5445c75993a26bf62d38d26ff5fcfbde06a7bd0087fc6"
+		url "https://files.pythonhosted.org/packages/e4/46/596311bb390c902b61499ff9fd5a355cdf85c8455737cb0f08c6c2c13e22/pyquery-1.4.0.tar.gz"
+		sha256 "4771db76bd14352eba006463656aef990a0147a0eeaf094725097acfa90442bf"
 	end
 
   resource "requests" do


### PR DESCRIPTION
Was able to replicate issue #192 and figured out how to fix that issue by simply updating the PyQuery dependency from 1.2.11 to 1.4.0. I found the download link from [here](https://pypi.org/project/pyquery/1.4.0/#files), which is the closest you can get to an official endorsement from pypi.org itself (even though the download itself is hosted at https://files.pythonhosted.org).

After updating the dependency, I was able to install howdoi using homebrew.