### PR TITLE
Remove unnecessary test code that supported Python 2.6

### DIFF
--- a/test_howdoi.py
+++ b/test_howdoi.py
@@ -4,7 +4,6 @@
 import os
 import unittest
 import re
-import sys
 
 from howdoi import howdoi
 
@@ -112,11 +111,7 @@ class HowdoiTestCase(unittest.TestCase):
         links = ['https://stackoverflow.com/questions/tagged/cat', 'http://rads.stackoverflow.com/amzn/click/B007KAZ166', 'https://stackoverflow.com/questions/40108569/how-to-get-the-last-line-of-a-file-using-cat-command']
         expected_output = ['https://stackoverflow.com/questions/40108569/how-to-get-the-last-line-of-a-file-using-cat-command']
         actual_output = howdoi._get_questions(links)
-        if sys.version < '2.7':
-            self.assertEqual(len(actual_output), len(expected_output))
-            self.assertEqual(sorted(actual_output), sorted(expected_output))
-        else:
-            self.assertSequenceEqual(actual_output, expected_output)
+        self.assertSequenceEqual(actual_output, expected_output)
 
 
 class HowdoiTestCaseEnvProxies(unittest.TestCase):


### PR DESCRIPTION
When writing automated tests for #177, I learned that
Python 2.6 did not have support for assertSequenceEqual. To ensure
that the automated tests could run on Python 2.6, I wrote some
additional code.

However, in #186, we dropped support for Python 2.6. Therefore,
we no longer need this code. Removing it would help simplify
the test code and make it easier to maintain.