### PR TITLE
Display links using markdown syntax

### DIFF
--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -101,16 +101,14 @@ def _add_links_to_text(element):
     hyperlinks = element.find('a')
 
     for hyperlink in hyperlinks:
+        pquery_object = pq(hyperlink)
         href = hyperlink.attrib['href']
-        copy = hyperlink.text
+        copy = pquery_object.text()
         if (copy == href):
             replacement = copy
         else:
             replacement = "[{0}]({1})".format(copy, href)
-        _replace_link(hyperlink, replacement)
-
-def _replace_link(hyperlink, replacement):
-    pq(hyperlink).replace_with(replacement)
+        pquery_object.replace_with(replacement)
 
 def _get_text(element):
     ''' return inner text in pyquery element '''

--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -97,8 +97,24 @@ def _get_result(url):
         raise e
 
 
+def _add_links_to_text(element):
+    duplicate_element = element.clone()
+    hyperlinks = duplicate_element.find('a')
+
+    for hyperlink in hyperlinks:
+        href = hyperlink.attrib['href']
+        copy = hyperlink.text
+        markdown = "[{0}]({1})".format(copy, href)
+        _replace_first_link_with_markdown(duplicate_element, markdown)
+
+    return duplicate_element
+
+def _replace_first_link_with_markdown(element, markdown):
+    element.find('a').eq(0).replace_with(markdown)
+
 def _get_text(element):
     ''' return inner text in pyquery element '''
+    element = _add_links_to_text(element)
     return element.text(squash_space=False)
 
 
@@ -186,6 +202,7 @@ def _get_answer(args, links):
     html = pq(page)
 
     first_answer = html('.answer').eq(0)
+
     instructions = first_answer.find('pre') or first_answer.find('code')
     args['tags'] = [t.text for t in html('.post-tag')]
 

--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -104,13 +104,16 @@ def _add_links_to_text(element):
     for hyperlink in hyperlinks:
         href = hyperlink.attrib['href']
         copy = hyperlink.text
-        markdown = "[{0}]({1})".format(copy, href)
-        _replace_first_link_with_markdown(duplicate_element, markdown)
+        if (copy == href):
+            replacement = copy
+        else:
+            replacement = "[{0}]({1})".format(copy, href)
+        _replace_first_link(duplicate_element, replacement)
 
     return duplicate_element
 
-def _replace_first_link_with_markdown(element, markdown):
-    element.find('a').eq(0).replace_with(markdown)
+def _replace_first_link(element, replacement):
+    element.find('a').eq(0).replace_with(replacement)
 
 def _get_text(element):
     ''' return inner text in pyquery element '''

--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -98,8 +98,7 @@ def _get_result(url):
 
 
 def _add_links_to_text(element):
-    duplicate_element = element.clone()
-    hyperlinks = duplicate_element.find('a')
+    hyperlinks = element.find('a')
 
     for hyperlink in hyperlinks:
         href = hyperlink.attrib['href']
@@ -108,16 +107,14 @@ def _add_links_to_text(element):
             replacement = copy
         else:
             replacement = "[{0}]({1})".format(copy, href)
-        _replace_first_link(duplicate_element, replacement)
+        _replace_link(hyperlink, replacement)
 
-    return duplicate_element
-
-def _replace_first_link(element, replacement):
-    element.find('a').eq(0).replace_with(replacement)
+def _replace_link(hyperlink, replacement):
+    pq(hyperlink).replace_with(replacement)
 
 def _get_text(element):
     ''' return inner text in pyquery element '''
-    element = _add_links_to_text(element)
+    _add_links_to_text(element)
     return element.text(squash_space=False)
 
 

--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -110,7 +110,7 @@ def _add_links_to_text(element):
             replacement = "[{0}]({1})".format(copy, href)
         pquery_object.replace_with(replacement)
 
-def _get_text(element):
+def get_text(element):
     ''' return inner text in pyquery element '''
     _add_links_to_text(element)
     return element.text(squash_space=False)
@@ -205,11 +205,11 @@ def _get_answer(args, links):
     args['tags'] = [t.text for t in html('.post-tag')]
 
     if not instructions and not args['all']:
-        text = _get_text(first_answer.find('.post-text').eq(0))
+        text = get_text(first_answer.find('.post-text').eq(0))
     elif args['all']:
         texts = []
         for html_tag in first_answer.items('.post-text > *'):
-            current_text = _get_text(html_tag)
+            current_text = get_text(html_tag)
             if current_text:
                 if html_tag[0].tag in ['pre', 'code']:
                     texts.append(_format_output(current_text, args))
@@ -217,7 +217,7 @@ def _get_answer(args, links):
                     texts.append(current_text)
         text = '\n'.join(texts)
     else:
-        text = _format_output(_get_text(instructions.eq(0)), args)
+        text = _format_output(get_text(instructions.eq(0)), args)
     if text is None:
         text = NO_ANSWER_MSG
     text = text.strip()

--- a/test_howdoi.py
+++ b/test_howdoi.py
@@ -108,9 +108,9 @@ class HowdoiTestCase(unittest.TestCase):
         self.assertTrue(colorized.find('[39;') is not -1)
 
     def test_get_text_without_links(self):
-        html = '\n  <p>The halting problem is basically a\n  formal way of asking if you can tell\n  whether or not an arbitrary program\n  will eventually halt.</p>\n  \n  <p>In other words, can you write a\n  program called a halting oracle,\n  HaltingOracle(program, input), which\n  returns true if program(input) would\n  eventually halt, and which returns\n  false if it wouldn’t?</p>\n  \n  <p>The answer is: no, you can’t.</p>\n'
+        html = '''\n  <p>The halting problem is basically a\n  formal way of asking if you can tell\n  whether or not an arbitrary program\n  will eventually halt.</p>\n  \n  <p>In other words, can you write a\n  program called a halting oracle,\n  HaltingOracle(program, input), which\n  returns true if program(input) would\n  eventually halt, and which returns\n  false if it wouldn't?</p>\n  \n  <p>The answer is: no, you can't.</p>\n'''
         paragraph = pq(html)
-        expected_output = 'The halting problem is basically a\n  formal way of asking if you can tell\n  whether or not an arbitrary program\n  will eventually halt.\n\n  \n  \nIn other words, can you write a\n  program called a halting oracle,\n  HaltingOracle(program, input), which\n  returns true if program(input) would\n  eventually halt, and which returns\n  false if it wouldn’t?\n\n  \n  \nThe answer is: no, you can’t.\n\n'
+        expected_output = '''The halting problem is basically a\n  formal way of asking if you can tell\n  whether or not an arbitrary program\n  will eventually halt.\n\n  \n  \nIn other words, can you write a\n  program called a halting oracle,\n  HaltingOracle(program, input), which\n  returns true if program(input) would\n  eventually halt, and which returns\n  false if it wouldn't?\n\n  \n  \nThe answer is: no, you can't.\n\n'''
         actual_output = howdoi._get_text(paragraph)
         self.assertEqual(actual_output, expected_output)
 

--- a/test_howdoi.py
+++ b/test_howdoi.py
@@ -111,42 +111,42 @@ class HowdoiTestCase(unittest.TestCase):
         html = '''\n  <p>The halting problem is basically a\n  formal way of asking if you can tell\n  whether or not an arbitrary program\n  will eventually halt.</p>\n  \n  <p>In other words, can you write a\n  program called a halting oracle,\n  HaltingOracle(program, input), which\n  returns true if program(input) would\n  eventually halt, and which returns\n  false if it wouldn't?</p>\n  \n  <p>The answer is: no, you can't.</p>\n'''
         paragraph = pq(html)
         expected_output = '''The halting problem is basically a\n  formal way of asking if you can tell\n  whether or not an arbitrary program\n  will eventually halt.\n\n  \n  \nIn other words, can you write a\n  program called a halting oracle,\n  HaltingOracle(program, input), which\n  returns true if program(input) would\n  eventually halt, and which returns\n  false if it wouldn't?\n\n  \n  \nThe answer is: no, you can't.\n\n'''
-        actual_output = howdoi._get_text(paragraph)
+        actual_output = howdoi.get_text(paragraph)
         self.assertEqual(actual_output, expected_output)
 
     def test_get_text_with_one_link(self):
         html = '<p>It\'s a <a href="http://paulirish.com/2010/the-protocol-relative-url/">protocol-relative URL</a> (typically HTTP or HTTPS). So if I\'m on <code>http://example.org</code> and I link (or include an image, script, etc.) to <code>//example.com/1.png</code>, it goes to <code>http://example.com/1.png</code>. If I\'m on <code>https://example.org</code>, it goes to <code>https://example.com/1.png</code>.</p>'
         paragraph = pq(html)
         expected_output = "It's a [protocol-relative URL](http://paulirish.com/2010/the-protocol-relative-url/) (typically HTTP or HTTPS). So if I'm on http://example.org and I link (or include an image, script, etc.) to //example.com/1.png, it goes to http://example.com/1.png. If I'm on https://example.org, it goes to https://example.com/1.png."
-        actual_output = howdoi._get_text(paragraph)
+        actual_output = howdoi.get_text(paragraph)
         self.assertEqual(actual_output, expected_output)
 
     def test_get_text_with_multiple_links_test_one(self):
         html = 'Here\'s a quote from <a href="http://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style#Links" rel="nofollow noreferrer">wikipedia\'s manual of style</a> section on links (but see also <a href="http://en.wikipedia.org/wiki/Wikipedia:External_links" rel="nofollow noreferrer">their comprehensive page on External Links</a>)'
         paragraph = pq(html)
         expected_output = "Here's a quote from [wikipedia's manual of style](http://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style#Links) section on links (but see also [their comprehensive page on External Links](http://en.wikipedia.org/wiki/Wikipedia:External_links))"
-        actual_output = howdoi._get_text(paragraph)
+        actual_output = howdoi.get_text(paragraph)
         self.assertEqual(actual_output, expected_output)
 
     def test_get_text_with_multiple_links_test_two(self):
         html = 'For example, if I were to reference <a href="http://www.apple.com/" rel="nofollow noreferrer">apple.com</a> as the subject of a sentence - or to talk about <a href="http://www.apple.com/" rel="nofollow noreferrer">Apple\'s website</a> as the topic of conversation. This being different to perhaps recommendations for reading <a href="https://ux.stackexchange.com/q/14872/6046">our article about Apple\'s website</a>.'
         paragraph = pq(html)
         expected_output = "For example, if I were to reference [apple.com](http://www.apple.com/) as the subject of a sentence - or to talk about [Apple's website](http://www.apple.com/) as the topic of conversation. This being different to perhaps recommendations for reading [our article about Apple's website](https://ux.stackexchange.com/q/14872/6046)."
-        actual_output = howdoi._get_text(paragraph)
+        actual_output = howdoi.get_text(paragraph)
         self.assertEqual(actual_output, expected_output)
 
     def test_get_text_with_link_but_with_copy_duplicating_the_href(self):
         html ='<a href="https://github.com/jquery/jquery/blob/56136897f241db22560b58c3518578ca1453d5c7/src/manipulation.js#L451" rel="nofollow noreferrer">https://github.com/jquery/jquery/blob/56136897f241db22560b58c3518578ca1453d5c7/src/manipulation.js#L451</a>'
         paragraph = pq(html)
         expected_output = 'https://github.com/jquery/jquery/blob/56136897f241db22560b58c3518578ca1453d5c7/src/manipulation.js#L451'
-        actual_output = howdoi._get_text(paragraph)
+        actual_output = howdoi.get_text(paragraph)
         self.assertEqual(actual_output, expected_output)
 
     def test_get_text_with_a_link_but_copy_is_within_nested_div(self):
         html = 'If the function is from a source file available on the filesystem, then <a href="https://docs.python.org/3/library/inspect.html#inspect.getsource" rel="noreferrer"><code>inspect.getsource(foo)</code></a> might be of help:'
         paragraph = pq(html)
         expected_output = 'If the function is from a source file available on the filesystem, then [inspect.getsource(foo)](https://docs.python.org/3/library/inspect.html#inspect.getsource) might be of help:'
-        actual_output = howdoi._get_text(paragraph)
+        actual_output = howdoi.get_text(paragraph)
         self.assertEqual(actual_output, expected_output)
 
     def test_get_questions(self):

--- a/test_howdoi.py
+++ b/test_howdoi.py
@@ -7,10 +7,9 @@ import re
 import sys
 
 from howdoi import howdoi
-
+from pyquery import PyQuery as pq
 
 class HowdoiTestCase(unittest.TestCase):
-
     def call_howdoi(self, query):
         parser = howdoi.get_parser()
         args = vars(parser.parse_args(query.split(' ')))
@@ -107,6 +106,34 @@ class HowdoiTestCase(unittest.TestCase):
         colorized = self.call_howdoi('-c ' + query)
         self.assertTrue(normal.find('[39;') is -1)
         self.assertTrue(colorized.find('[39;') is not -1)
+
+    def test_get_text_without_links(self):
+        html = '\n  <p>The halting problem is basically a\n  formal way of asking if you can tell\n  whether or not an arbitrary program\n  will eventually halt.</p>\n  \n  <p>In other words, can you write a\n  program called a halting oracle,\n  HaltingOracle(program, input), which\n  returns true if program(input) would\n  eventually halt, and which returns\n  false if it wouldn’t?</p>\n  \n  <p>The answer is: no, you can’t.</p>\n'
+        paragraph = pq(html)
+        expected_output = 'The halting problem is basically a\n  formal way of asking if you can tell\n  whether or not an arbitrary program\n  will eventually halt.\n\n  \n  \nIn other words, can you write a\n  program called a halting oracle,\n  HaltingOracle(program, input), which\n  returns true if program(input) would\n  eventually halt, and which returns\n  false if it wouldn’t?\n\n  \n  \nThe answer is: no, you can’t.\n\n'
+        actual_output = howdoi._get_text(paragraph)
+        self.assertEqual(actual_output, expected_output)
+
+    def test_get_text_with_one_link(self):
+        html = '<p>It\'s a <a href="http://paulirish.com/2010/the-protocol-relative-url/">protocol-relative URL</a> (typically HTTP or HTTPS). So if I\'m on <code>http://example.org</code> and I link (or include an image, script, etc.) to <code>//example.com/1.png</code>, it goes to <code>http://example.com/1.png</code>. If I\'m on <code>https://example.org</code>, it goes to <code>https://example.com/1.png</code>.</p>'
+        paragraph = pq(html)
+        expected_output = "It's a [protocol-relative URL](http://paulirish.com/2010/the-protocol-relative-url/) (typically HTTP or HTTPS). So if I'm on http://example.org and I link (or include an image, script, etc.) to //example.com/1.png, it goes to http://example.com/1.png. If I'm on https://example.org, it goes to https://example.com/1.png."
+        actual_output = howdoi._get_text(paragraph)
+        self.assertEqual(actual_output, expected_output)
+
+    def test_get_text_with_multiple_links_test_one(self):
+        html = 'Here\'s a quote from <a href="http://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style#Links" rel="nofollow noreferrer">wikipedia\'s manual of style</a> section on links (but see also <a href="http://en.wikipedia.org/wiki/Wikipedia:External_links" rel="nofollow noreferrer">their comprehensive page on External Links</a>)'
+        paragraph = pq(html)
+        expected_output = "Here's a quote from [wikipedia's manual of style](http://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style#Links) section on links (but see also [their comprehensive page on External Links](http://en.wikipedia.org/wiki/Wikipedia:External_links))"
+        actual_output = howdoi._get_text(paragraph)
+        self.assertEqual(actual_output, expected_output)
+
+    def test_get_text_with_multiple_links_test_two(self):
+        html = 'For example, if I were to reference <a href="http://www.apple.com/" rel="nofollow noreferrer">apple.com</a> as the subject of a sentence - or to talk about <a href="http://www.apple.com/" rel="nofollow noreferrer">Apple\'s website</a> as the topic of conversation. This being different to perhaps recommendations for reading <a href="https://ux.stackexchange.com/q/14872/6046">our article about Apple\'s website</a>.'
+        paragraph = pq(html)
+        expected_output = "For example, if I were to reference [apple.com](http://www.apple.com/) as the subject of a sentence - or to talk about [Apple's website](http://www.apple.com/) as the topic of conversation. This being different to perhaps recommendations for reading [our article about Apple's website](https://ux.stackexchange.com/q/14872/6046)."
+        actual_output = howdoi._get_text(paragraph)
+        self.assertEqual(actual_output, expected_output)
 
     def test_get_questions(self):
         links = ['https://stackoverflow.com/questions/tagged/cat', 'http://rads.stackoverflow.com/amzn/click/B007KAZ166', 'https://stackoverflow.com/questions/40108569/how-to-get-the-last-line-of-a-file-using-cat-command']

--- a/test_howdoi.py
+++ b/test_howdoi.py
@@ -142,6 +142,13 @@ class HowdoiTestCase(unittest.TestCase):
         actual_output = howdoi._get_text(paragraph)
         self.assertEqual(actual_output, expected_output)
 
+    def test_get_text_with_a_link_but_copy_is_within_nested_div(self):
+        html = 'If the function is from a source file available on the filesystem, then <a href="https://docs.python.org/3/library/inspect.html#inspect.getsource" rel="noreferrer"><code>inspect.getsource(foo)</code></a> might be of help:'
+        paragraph = pq(html)
+        expected_output = 'If the function is from a source file available on the filesystem, then [inspect.getsource(foo)](https://docs.python.org/3/library/inspect.html#inspect.getsource) might be of help:'
+        actual_output = howdoi._get_text(paragraph)
+        self.assertEqual(actual_output, expected_output)
+
     def test_get_questions(self):
         links = ['https://stackoverflow.com/questions/tagged/cat', 'http://rads.stackoverflow.com/amzn/click/B007KAZ166', 'https://stackoverflow.com/questions/40108569/how-to-get-the-last-line-of-a-file-using-cat-command']
         expected_output = ['https://stackoverflow.com/questions/40108569/how-to-get-the-last-line-of-a-file-using-cat-command']

--- a/test_howdoi.py
+++ b/test_howdoi.py
@@ -135,6 +135,13 @@ class HowdoiTestCase(unittest.TestCase):
         actual_output = howdoi._get_text(paragraph)
         self.assertEqual(actual_output, expected_output)
 
+    def test_get_text_with_link_but_with_copy_duplicating_the_href(self):
+        html ='<a href="https://github.com/jquery/jquery/blob/56136897f241db22560b58c3518578ca1453d5c7/src/manipulation.js#L451" rel="nofollow noreferrer">https://github.com/jquery/jquery/blob/56136897f241db22560b58c3518578ca1453d5c7/src/manipulation.js#L451</a>'
+        paragraph = pq(html)
+        expected_output = 'https://github.com/jquery/jquery/blob/56136897f241db22560b58c3518578ca1453d5c7/src/manipulation.js#L451'
+        actual_output = howdoi._get_text(paragraph)
+        self.assertEqual(actual_output, expected_output)
+
     def test_get_questions(self):
         links = ['https://stackoverflow.com/questions/tagged/cat', 'http://rads.stackoverflow.com/amzn/click/B007KAZ166', 'https://stackoverflow.com/questions/40108569/how-to-get-the-last-line-of-a-file-using-cat-command']
         expected_output = ['https://stackoverflow.com/questions/40108569/how-to-get-the-last-line-of-a-file-using-cat-command']


### PR DESCRIPTION
From the commit message:

>Some answers on the StackExchange network include hyperlinks
to other content on the Internet. Ideally, those hyperlinks would serve
as "supplemental" reading, but there has been instances where the hyperlink
contains most of the answer (the so-called "link-only answers").

>howdoi currently ignores all hyperlinks within the answer of the
question, preferring instead to display a raw-text version of the answer.
While this is suitable for most instances, there are a few cases
where you may want to dig deeper and follow those hyperlinks, especially
if you have encountered a "link-only answer". Rather than viewing the
StackExchange answer through the browser and risk distraction,
it would be preferable to see the hyperlinks directly in the terminal.

In the future, I may also like to see image URLs show up in the terminal, to handle the case where the answer includes an image as "supplemental" material. Right now, I'm just checking to see if this is a feature that you might want to add to howdoi.