### PR TITLE
Add snapcraft.yaml file for snap package distribution

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,61 @@
+name: howdoi
+summary: Instant coding answers via the command line
+adopt-info: howdoi
+confinement: strict
+grade: stable
+description: |
+  Are you a hack programmer? Do you find yourself constantly Googling for how
+  to do basic programming tasks?
+
+  Suppose you want to know how to format a date in bash. Why open your browser
+  and read through blogs (risking major distraction) when you can simply stay
+  in the console and ask howdoi:
+
+  $ howdoi format date bash
+  > DATE=`date +%Y-%m-%d`
+
+  howdoi will answer all sorts of queries:
+
+  $ howdoi print stack trace python
+  > import traceback
+  >
+  > try:
+  >     1/0
+  > except:
+  >     print '>>> traceback <<<'
+  >     traceback.print_exc()
+  >     print '>>> end of traceback <<<'
+  > traceback.print_exc()
+
+  $ howdoi convert mp4 to animated gif
+  > video=/path/to/video.avi
+  > outdir=/path/to/output.gif
+  > mplayer "$video" \
+  >         -ao null \
+  >         -ss "00:01:00" \  # starting point
+  >         -endpos 10 \ # duration in second
+  >         -vo gif89a:fps=13:output=$outdir \
+  >         -vf scale=240:180
+
+  $ howdoi create tar archive
+  > tar -cf backup.tar --exclude "www/subf3" www
+
+apps:
+  howdoi:
+    command: howdoi
+    plugs:
+      - network
+
+parts:
+  howdoi:
+    plugin: python
+    source: https://github.com/gleitz/howdoi.git
+    source-type: git
+    override-pull: |
+      # Need to override the version here to match the version used in the
+      # setuptools. Unfortunately, the snapcraft piece which has the ability
+      # to parse-info from setup.py fails due to being unable to import the
+      # howdoi module. Until that's fixed, simply parse it from __init__.py
+      snapcraftctl pull
+      VERSION="$(awk -F\' '/__version__/ { print $2 }' < howdoi/__init__.py)"
+      snapcraftctl set-version "${VERSION}"


### PR DESCRIPTION
This commit introduces support the bundling/delivering howdoi through
the 'snap' mechanism/store - for more details see https://snapcraft.io.

"A snap is a bundle of your app and its dependencies that works without
modification across Linux.  Snaps are discoverable and installable from
the Snap store, an app store with an audience of millions." [1]

In case the snapcraft.yaml file is accepted it can be published in the
Snap Store [2] which is required for people to easily install it.

Assistance for publishing in the snap store is available if desired.

Test Procedure
==============

Build/Snap
----------

Create an LXC container to do your snapcrafting in
```
$ lxc launch ubuntu:16.04 snapcrafting  # create 'snapcrafting' container
$ lxc exec snapcrafting -- su - ubuntu  # execute user shell in container
```

Install the snapcraft tools
```
$ sudo snap install snapcraft --classic # install snapcraft tool/commands
$ sudo apt-get update # update for installing build dependencies packages
```

Download the repository
```
$ git clone https://github.com/gleitz/howdoi
$ cd howdoi
```

Get the snapcraft.yaml file included in this PR and then run ```snapcraft```:
```
$ snapcraft
...
Building howdoi
Looking in links: /root/build_howdoi/parts/howdoi/python-packages
Processing /root/build_howdoi/parts/howdoi/build
Collecting pyquery (from howdoi==1.1.14)
  Saved /tmp/tmpvh8th26d/pyquery-1.4.0-py2.py3-none-any.whl
Collecting pygments (from howdoi==1.1.14)
  Saved /tmp/tmpvh8th26d/Pygments-2.3.0-py2.py3-none-any.whl
Collecting requests (from howdoi==1.1.14)
  Saved /tmp/tmpvh8th26d/requests-2.21.0-py2.py3-none-any.whl
...
Building wheels for collected packages: howdoi
  Running setup.py bdist_wheel for howdoi ... done
  Stored in directory: /tmp/tmpvh8th26d
Successfully built howdoi
...
Staging howdoi
Priming howdoi
Snapping 'howdoi' |
Snapped howdoi_amd64.snap

```
Install/Contents
----------------
Install the built snap using the following:
```
$ sudo snap install howdoi_amd64.snap --dangerous
```
_note: '--dangerous' is required because the snap is not sourced from the store._

Note the howdoi installed is the one included from the snap
```
$ which howdoi
/snap/bin/howdoi
```

If you're interested in the contents, you can look for the files in the /snap/howdoi/ directory
```
$ find /snap/howdoi/
...
/snap/howdoi/x1/bin/howdoi
...
/snap/howdoi/x1/lib/python3.5/site-packages/howdoi
/snap/howdoi/x1/lib/python3.5/site-packages/howdoi/__init__.py
/snap/howdoi/x1/lib/python3.5/site-packages/howdoi/howdoi.py
/snap/howdoi/x1/lib/python3.5/site-packages/howdoi-1.1.14-py3.5.egg-info
/snap/howdoi/x1/lib/python3.5/site-packages/howdoi-1.1.14-py3.5.egg-info/PKG-INFO
/snap/howdoi/x1/lib/python3.5/site-packages/howdoi-1.1.14-py3.5.egg-info/SOURCES.txt
/snap/howdoi/x1/lib/python3.5/site-packages/howdoi-1.1.14-py3.5.egg-info/dependency_links.txt
/snap/howdoi/x1/lib/python3.5/site-packages/howdoi-1.1.14-py3.5.egg-info/entry_points.txt
/snap/howdoi/x1/lib/python3.5/site-packages/howdoi-1.1.14-py3.5.egg-info/requires.txt
/snap/howdoi/x1/lib/python3.5/site-packages/howdoi-1.1.14-py3.5.egg-info/top_level.txt
/snap/howdoi/x1/lib/python3.5/site-packages/howdoi-1.1.14.dist-info
/snap/howdoi/x1/lib/python3.5/site-packages/howdoi-1.1.14.dist-info/INSTALLER
/snap/howdoi/x1/lib/python3.5/site-packages/howdoi-1.1.14.dist-info/LICENSE.txt
/snap/howdoi/x1/lib/python3.5/site-packages/howdoi-1.1.14.dist-info/METADATA
/snap/howdoi/x1/lib/python3.5/site-packages/howdoi-1.1.14.dist-info/WHEEL
/snap/howdoi/x1/lib/python3.5/site-packages/howdoi-1.1.14.dist-info/entry_points.txt
/snap/howdoi/x1/lib/python3.5/site-packages/howdoi-1.1.14.dist-info/top_level.txt
...
```

Testing
-------

```
$ howdoi format date bash
DATE=`date +%Y-%m-%d`
```

```
$ howdoi get current time python
>>> import datetime
>>> datetime.datetime.now()
datetime.datetime(2009, 1, 6, 15, 8, 24, 78915)

>>> print(datetime.datetime.now())
2018-07-29 09:17:13.812189
```

References:
[1] "Creating a snap" in https://docs.snapcraft.io/creating-a-snap/6799
[2] "Share with your friends" in https://docs.snapcraft.io/python-apps/6741

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>