### PR TITLE
Lazily load pygments to cut start-up time significantly

### DIFF
--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -18,6 +18,9 @@ import requests_cache
 import sys
 from . import __version__
 
+from lazyasd import load_module_in_background
+load_module_in_background('pygments')
+
 from pygments import highlight
 from pygments.lexers import guess_lexer, get_lexer_by_name
 from pygments.formatters.terminal import TerminalFormatter

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ lxml==4.2.5
 pyquery==1.4.0
 requests==2.20.1
 requests-cache==0.4.13
+lazyasd==0.1.4


### PR DESCRIPTION
Pygments is notorious for slow imports. Load it lazily = win.