### PR TITLE
Replace requests_cache with a light, filesystem-based cache

### DIFF
--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -91,7 +91,7 @@ else:
 
 howdoi_session = requests.session()
 
-class BlockError(Exception):
+class BlockError(RuntimeError):
     pass
 
 def _random_int(width):

--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -231,7 +231,6 @@ def _get_questions(links):
     return [link for link in links if _is_question(link)]
 
 
-
 def _get_answer(args, links):
     link = get_link_at_pos(links, args['pos'])
     if not link:
@@ -271,7 +270,7 @@ def _get_answer(args, links):
     text = text.strip()
     return text
 
-def _get_cachable_questions(query):
+def _get_links_with_cache(query):
     cache_key = query + "-links"
     res = cache.get(cache_key)
     if res:
@@ -289,7 +288,7 @@ def _get_cachable_questions(query):
     return question_links
 
 def _get_instructions(args):
-    question_links = _get_cachable_questions(args['query'])
+    question_links = _get_links_with_cache(args['query'])
     if not question_links:
         return False
 

--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -75,6 +75,7 @@ STAR_HEADER = u('\u2605')
 ANSWER_HEADER = u('{2}  Answer from {0} {2}\n{1}')
 NO_ANSWER_MSG = '< no answer given >'
 
+CACHE_EMPTY_VAL = "NULL"
 CACHE_DIR = appdirs.user_cache_dir('howdoi')
 CACHE_ENTRY_MAX = 128
 
@@ -274,16 +275,16 @@ def _get_links_with_cache(query):
     cache_key = query + "-links"
     res = cache.get(cache_key)
     if res:
-        if res == "NULL":
+        if res == CACHE_EMPTY_VAL:
             res = False
         return res
 
     links = _get_links(query)
     if not links:
-        cache.set(cache_key, "NULL")
+        cache.set(cache_key, CACHE_EMPTY_VAL)
 
     question_links = _get_questions(links)
-    cache.set(cache_key, question_links or "NULL")
+    cache.set(cache_key, question_links or CACHE_EMPTY_VAL)
 
     return question_links
 

--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -13,7 +13,6 @@ gc.disable() # disable right at the start, we don't need it
 import argparse
 import os
 import appdirs
-import random
 import re
 from cachelib import FileSystemCache
 import requests
@@ -80,6 +79,18 @@ else:
 
 howdoi_session = requests.session()
 
+def _random_int(width):
+    bres = os.urandom(width)
+    if sys.version < '3':
+        ires = int(bres.encode('hex'), 16)
+    else:
+        ires = int.from_bytes(bres, 'little')
+
+    return ires
+
+def _random_choice(seq):
+    return seq[_random_int(1) % len(seq)]
+
 def get_proxies():
     proxies = getproxies()
     filtered_proxies = {}
@@ -94,7 +105,7 @@ def get_proxies():
 
 def _get_result(url):
     try:
-        return howdoi_session.get(url, headers={'User-Agent': random.choice(USER_AGENTS)},
+        return howdoi_session.get(url, headers={'User-Agent': _random_choice(USER_AGENTS)},
                                   proxies=get_proxies(),
                                   verify=VERIFY_SSL_CERTIFICATE).text
     except requests.exceptions.SSLError as e:

--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -171,7 +171,7 @@ def _extract_links(html, search_engine):
 def _get_search_url(search_engine):
     return SEARCH_URLS.get(search_engine, SEARCH_URLS['google'])
 
-def _detect_block(page):
+def _is_blocked(page):
     for indicator in BLOCK_INDICATORS:
         if page.find(indicator) != -1:
             return True
@@ -183,7 +183,7 @@ def _get_links(query):
     search_url = _get_search_url(search_engine)
 
     result = _get_result(search_url.format(URL, url_quote(query)))
-    if _detect_block(result):
+    if _is_blocked(result):
         _print_err('Unable to find an answer because the search engine temporarily blocked the request. '
                 'Please wait a few minutes or select a different search engine.')
         raise BlockError("Temporary block by search engine")

--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -68,6 +68,7 @@ SEARCH_URLS = {
 
 BLOCK_INDICATORS = (
         'form id="captcha-form"',
+        'This page appears when Google automatically detects requests coming from your computer network which appear to be in violation of the <a href="//www.google.com/policies/terms/">Terms of Service'
         )
 
 STAR_HEADER = u('\u2605')
@@ -164,6 +165,12 @@ def _extract_links(html, search_engine):
 def _get_search_url(search_engine):
     return SEARCH_URLS.get(search_engine, SEARCH_URLS['google'])
 
+def _detect_block(page):
+    for indicator in BLOCK_INDICATORS:
+        if page.find(indicator) != -1:
+            return True
+
+    return False
 
 def _get_links(query):
     search_engine = os.getenv('HOWDOI_SEARCH_ENGINE', 'google')
@@ -224,13 +231,6 @@ def _get_questions(links):
     return [link for link in links if _is_question(link)]
 
 
-def _detect_block(page):
-    for indicator in BLOCK_INDICATORS:
-        if page.find(indicator):
-            return True
-
-    return False
-    
 
 def _get_answer(args, links):
     link = get_link_at_pos(links, args['pos'])

--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -7,6 +7,7 @@
 # inspired by Rich Jones (rich@anomos.info)
 #
 ######################################################
+from __future__ import print_function
 import gc
 gc.disable() # disable right at the start, we don't need it
 
@@ -44,6 +45,10 @@ else:
     def u(x):
         return x
 
+# rudimentary standardized 3-level log output
+_print_err = lambda x: print("[ERROR] " + x)
+_print_ok = print
+_print_dbg = lambda x: print("[DEBUG] " + x)
 
 if os.getenv('HOWDOI_DISABLE_SSL'):  # Set http instead of https
     SCHEME = 'http://'
@@ -119,7 +124,7 @@ def _get_result(url):
                                   proxies=get_proxies(),
                                   verify=VERIFY_SSL_CERTIFICATE).text
     except requests.exceptions.SSLError as e:
-        print('[ERROR] Encountered an SSL Error. Try using HTTP instead of '
+        _print_err('Encountered an SSL Error. Try using HTTP instead of '
               'HTTPS by setting the environment variable "HOWDOI_DISABLE_SSL".\n')
         raise e
 
@@ -179,8 +184,8 @@ def _get_links(query):
 
     result = _get_result(search_url.format(URL, url_quote(query)))
     if _detect_block(result):
-        print('[ERROR] Encountered a temporary block due to automated request '
-                'detection. Please wait a few minutes for it to clear or change search engine')
+        _print_err('Unable to find an answer because the search engine temporarily blocked the request. '
+                'Please wait a few minutes or select a different search engine.')
         raise BlockError("Temporary block by search engine")
     
     html = pq(result)
@@ -371,14 +376,14 @@ def command_line_runner():
     args = vars(parser.parse_args())
 
     if args['version']:
-        print(__version__)
+        _print_ok(__version__)
         return
 
     if args['clear_cache']:
         if _clear_cache():
-            print('Cache cleared successfully')
+            _print_ok('Cache cleared successfully')
         else:
-            print('Error: clearing cache failed')
+            _print_err('Clearing cache failed')
 
         return
 

--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -342,7 +342,7 @@ def command_line_runner():
         if _clear_cache():
             print('Cache cleared successfully')
         else:
-            Print('Error: clearing cache failed')
+            print('Error: clearing cache failed')
 
         return
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ lxml==4.2.5
 pyquery==1.4.0
 requests==2.20.1
 requests-cache==0.4.13
+cachelib==0.1
+appdirs=1.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,5 @@ cssselect==1.0.3
 lxml==4.2.5
 pyquery==1.4.0
 requests==2.20.1
-requests-cache==0.4.13
 cachelib==0.1
 appdirs==1.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ pyquery==1.4.0
 requests==2.20.1
 requests-cache==0.4.13
 cachelib==0.1
-appdirs=1.4.3
+appdirs==1.4.3

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,5 @@ setup(
         'pyquery',
         'pygments',
         'requests',
-        'requests-cache'
     ] + extra_dependencies(),
 )


### PR DESCRIPTION
See #224 for overall discussion.

Additional changes not mentioned there:
 * Use appdirs to find cache directory less kludgily, should now work on Windows as a by-product (not tested though, don't have a Windows machine)
 * Remove import random and use a simple internal randomizer based on os.urandom to select User-Agent

Still to come:
* Second-level cache so we don't have to hit upstream again when user wants full answer, second answer, different colorization setting etc