### PR TITLE
Fix inconsistency between command line parser definition and use of t…

### DIFF
--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -390,7 +390,7 @@ def get_parser():
                         action='store_true')
     parser.add_argument('-v', '--version', help='displays the current version of howdoi',
                         action='store_true')
-    parser.add_argument('-e', '--engine', help='change search engine for this query only',
+    parser.add_argument('-e', '--engine', help='change search engine for this query only', dest='search_engine',
                         nargs="?", default='google', const='bing') #google if -e not specified, bing if -e specified without positional arg.
     return parser
 


### PR DESCRIPTION
…he 'search_engine' key in command_line_runner() which causes a KeyError exception.