### PR TITLE
Add flexible raw query argument to howdoi.howdoi

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -134,7 +134,16 @@ Development
 -  Checkout the repo
 -  Run ``python -m howdoi.howdoi QUERY`` (if you try running ``python howdoi/howdoi.py`` you might get ``ValueError: Attempted relative import in non-package``).
 
-If you would like to use howdoi from within a python script, use the following snippet:
+If you would like to use howdoi from within a python script, just pass your query to `howdoi.howdoi()`:
+::
+
+    from howdoi import howdoi
+
+    query = "for loop python"
+    output = howdoi.howdoi(query)
+
+
+Or parse it yourself (either work):
 
 ::
 

--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -372,7 +372,12 @@ def _clear_cache():
     return cache.clear()
 
 
-def howdoi(args):
+def howdoi(raw_query):
+    args = raw_query
+    if type(raw_query) is str:  # you can pass either a raw or a parsed query
+        parser = get_parser()
+        args = vars(parser.parse_args(raw_query.split(' ')))
+
     args['query'] = ' '.join(args['query']).replace('?', '')
     cache_key = str(args)
 

--- a/test_howdoi.py
+++ b/test_howdoi.py
@@ -12,9 +12,7 @@ from pyquery import PyQuery as pq
 
 class HowdoiTestCase(unittest.TestCase):
     def call_howdoi(self, query):
-        parser = howdoi.get_parser()
-        args = vars(parser.parse_args(query.split(' ')))
-        return howdoi.howdoi(args)
+        return howdoi.howdoi(query)
 
     def setUp(self):
         self.queries = ['format date bash',


### PR DESCRIPTION
`howdoi.howdoi` accepts both parsed and raw queries to be passed directly to it. So the following snippet:
```python
from howdoi import howdoi

query = "for loop python"
parser = howdoi.get_parser()
args = vars(parser.parse_args(query.split(' ')))

output = howdoi.howdoi(args)
```
Can **also** be written as:
```python
from howdoi import howdoi

query = "for loop python"
output = howdoi.howdoi(query)
```
This doesn't break compatibility with the previous version.