### PR TITLE
MKdocs setup

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,31 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+
+    - name: Install Pip
+      run:  python -m pip install --upgrade pip
+
+    - name: Install dependencies
+      run: pip install mkdocs && pip install mkdocs-material markdown-include
+
+    - name: Build docs
+      run:  python -m mkdocs build
+
+    - name: Deploy MkDocs
+      uses: mhausenblas/mkdocs-deploy-gh-pages@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+site/
 build/
 develop-eggs/
 dist/

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,207 @@
+## General guidelines
+
+Be sure to go through these items before creating a new issue:
+
+1. Check the [existing issues](https://github.com/gleitz/howdoi/issues) to see if anyone is already working or have already worken on your issue or a similar one.
+
+2. If there are no current or past issues similar to yours, be sure to give a a **complete description** when creating it.
+
+3. Wait for feedback on the issue before starting to work.
+
+!!! tip
+    Include instructions on how to reproduce the bug you found or specific use cases of a requested feature.
+
+!!! Note
+    Follow Github's [guide to collaborating efficiently](https://lab.github.com/githubtraining/introduction-to-github).
+
+
+
+## Setting up development environment
+
+Clone the git repository
+```bash
+$ git clone https://github.com/gleitz/howdoi.git
+```
+
+Setup and activate a virtual environment
+```bash
+$ python3 -m venv .venv
+$ source .venv/bin/activate
+```
+
+Install packages
+```bash
+$ pip install -r requirements.txt
+```
+
+## Running howdoi
+
+Run on the command-line
+```bash
+python -m howdoi.howdoi QUERY
+```
+
+!!! note
+    If you try running `python howdoi/howdoi.py` (without `-m`) you might get `ValueError: Attempted relative import in non-package`.
+
+If you want to use howdoi from within a python script, just pass your query to `howdoi.howdoi()`
+
+```python
+from howdoi import howdoi
+
+query = "for loop python"
+output = howdoi.howdoi(query)
+```
+
+Or parse it yourself and passed the arguments to `howdoi.howdoi()`
+```python
+from howdoi import howdoi
+
+query = "for loop python"
+parser = howdoi.get_parser()
+args = vars(parser.parse_args(query.split(' ')))
+
+output = howdoi.howdoi(args)
+```
+
+!!! attention
+    Parsing queries yourself is the older way to pass in queries and may be deprecated in the future. Prefer the first example.
+
+
+## Submitting Pull Requests
+Before PRs are accepted they must pass all [Travis tests](https://travis-ci.org/gleitz/howdoi) and not have any `flake8` or `pylint` warnings or errors.
+
+#### Testing
+Howdoi uses python's [`unittest`](https://docs.python.org/3/library/unittest.html) library for unit testing. Run the unit tests locally
+
+```bash
+$ python -m test_howdoi
+```
+
+It's also possible to run only specific tests
+
+```bash
+$ python -m unittest test_howdoi.TestClass.test_method
+```
+
+Make sure all tests pass before submitting a PR.
+
+!!! tip
+    Remmember to run the tests while inside the virtual environment (run `source .venv/bin/activate` to activate it).
+
+#### Linting
+Run linting locally with [`flake8`](https://flake8.pycqa.org/en/latest/)
+```bash
+$ flake8
+```
+Or [`pylint`](https://www.pylint.org/)
+```bash
+$ pylint *
+```
+
+!!! tip
+    Howdoi uses vanilla configuration files for both linters (`.flake8rc` and `.pylintrc` in the root directory), but with a max line length of 119 characters.
+
+
+## Documentation
+
+To get started building the docs first download `mkdocs`
+
+```bash
+$ pip install mkdocs-material markdown-include
+```
+
+#### Commands
+
+* `python -m mkdocs new [dir-name]` - Create a new project.
+* `python -m mkdocs serve` - Start the live-reloading docs server.
+* `python -m mkdocs build` - Build the documentation site.
+* `python -m mkdocs help` - Print this help message.
+
+
+#### Project layout
+
+    mkdocs.yml    # The configuration file.
+    docs/
+        index.md  # The documentation homepage.
+        ...       # Other markdown pages, images and other files.
+
+
+#### Here are some example alerts you can use
+These are from the [Adomonition](https://python-markdown.github.io/extensions/admonition/) extension
+
+!!! attention
+    attention alert
+
+!!! caution
+    caution alert
+
+!!! warning
+    warning alert
+
+!!! danger
+    danger alert
+
+!!! error
+    error alert
+
+!!! hint
+    hint alert
+
+!!! important
+    important alert
+
+!!! tip
+    tip alert
+
+!!! note
+    note alert
+
+!!! Custom alert
+    Custom alert
+
+Alternatively you can use the `!!! type "Custom Title"` format to get the correct type emoji and use any title you want like so:
+
+!!! tip "Tip type alert but with a custom title"
+    they're good aren't they
+
+#### Include source code in 1 line of code
+
+To import code we can use this syntax inside of a code block with the language label:  "{\!path/to/file\!}".
+
+Here's `../howdoi/__init__.py`
+
+```Python
+{!../howdoi/__init__.py!}
+```
+
+#### Here is a choice tab
+Proper syntax highlighted code blocks in these don't work the way you'd think and I don't know how to get them to work normally without some extension
+
+=== "Python"
+    To do x in python use this code:
+
+    ```python
+    def main():
+        print("Hello world")
+    if __name__ == "__main__":
+        main()
+    ```
+
+=== "Golang"
+    To do x in golang use this code:
+
+    ```go
+    package main
+    import "fmt"
+    func main() {
+        fmt.Println("Hello world")
+    }
+    ```
+
+
+You can include the contents of a file
+```Python
+{!../howdoi/__init__.py!}
+```
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,41 @@
+# howdoi
+Never have open your browser to look for answers again.
+
+Create tar archive:
+```bash
+$ howdoi create tar archive
+> tar -cf backup.tar --exclude "www/subf3" www
+```
+
+Format a date in bash:
+```bash
+$ howdoi format date bash
+> DATE=`date +%Y-%m-%d`
+```
+Print stack trace in Python:
+``` bash
+$ howdoi print stack trace python
+> import traceback
+>
+> try:
+>     1/0
+> except:
+>     print '>>> traceback <<<'
+>     traceback.print_exc()
+>     print '>>> end of traceback <<<'
+> traceback.print_exc()
+```
+
+Convert MP4 to GIF:
+```bash
+$ howdoi convert mp4 to animated gif
+> video=/path/to/video.avi
+> outdir=/path/to/output.gif
+> mplayer "$video" \
+>         -ao null \
+>         -ss "00:01:00" \  # starting point
+>         -endpos 10 \ # duration in second
+>         -vo gif89a:fps=13:output=$outdir \
+>         -vf scale=240:180
+```
+

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,22 @@
+### How can I install howdoi?
+
+To install howdoi the most straight forward method is through [pip](https://pip.pypa.io/en/stable/). If you already have pip installed you can simply run:
+
+``
+pip install howdoi
+``
+
+or
+
+``
+pip install git+https://github.com/gleitz/howdoi.git#egg=howdoi
+``
+
+!!! Note
+    Don't have pip installed yet? [Follow this simple tutorial to get started](https://pip.pypa.io/en/stable/installing/)
+
+If you want to use [setuptools]() to install howdoi you can do so like this:
+
+``
+python setup.py install
+``

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,18 @@
+You might get the following error when installing with Homebrew:
+
+```bash
+==> python setup.py install
+
+http://peak.telecommunity.com/EasyInstall.html
+
+Please make the appropriate changes for your system and try again.
+```
+
+Fix the error by executing the following command:
+```bash
+sudo chmod -R go+w /Library/Python/2.7/site-packages/
+```
+
+An official lxml for python 3.3+ for windows has not yet been released. You may get an error while installing.
+Try and install an [unofficial binary for lxml](http://www.lfd.uci.edu/~gohlke/pythonlibs/#lxml).
+```

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,0 +1,45 @@
+## Usage
+
+If that's your first time using howdoi, run the quick help
+
+```bash
+$ howdoi howdoi
+```
+
+
+Print the help manual
+```bash
+$ howdoi # "howdoi -h" also prints help
+
+usage: howdoi.py [-h] [-p POS] [-n NUM] [-a] [-l] [-c] [-C] [-j] [-v] [-e [ENGINE]]
+                 [--save] [--view] [--remove] [--empty] [QUERY ...]
+
+instant coding answers via the command line
+
+positional arguments:
+  QUERY                 the question to answer
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -p POS, --pos POS     select answer in specified position (default: 1)
+  -n NUM, --num NUM     number of answers to return (default: 1)
+  -a, --all             display the full text of the answer
+  -l, --link            display only the answer link
+  -c, --color           enable colorized output
+  -C, --clear-cache     clear the cache
+  -j, --json            return answers in raw json format
+  -v, --version         displays the current version of howdoi
+  -e [ENGINE], --engine [ENGINE]
+                        search engine for this query (google, bing, duckduckgo)
+  --save, --stash       stash a howdoi answer
+  --view                view your stash
+  --remove              remove an entry in your stash
+  --empty               empty your stash
+
+environment variable examples:
+  HOWDOI_COLORIZE=1
+  HOWDOI_DISABLE_CACHE=1
+  HOWDOI_DISABLE_SSL=1
+  HOWDOI_SEARCH_ENGINE=google
+  HOWDOI_URL=serverfault.com
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,42 @@
+site_name: howdoi
+
+theme:
+    name: 'material'
+    palette:
+        primary: ''
+        accent: 'teal'
+    icon:
+        repo: fontawesome/brands/github
+
+repo_name: gleitz/howdoi
+repo_url: https://github.com/gleitz/howdoi
+edit_uri: ''
+
+nav:
+    - howdoi: index.md
+    - Installation: installation.md
+    - "User Guide": user-guide.md
+    - Contributing: contributing.md
+    - Troubleshooting: troubleshooting.md
+
+markdown_extensions:
+    - toc:
+        permalink: true
+    - markdown.extensions.codehilite:
+        guess_lang: false
+    - markdown_include.include:
+        base_path: docs
+    - admonition
+    - codehilite
+    - extra
+    - pymdownx.superfences:
+        custom_fences:
+            - name: mermaid
+              class: mermaid
+              format: !!python/name:pymdownx.superfences.fence_div_format
+    - pymdownx.tabbed
+
+extra:
+    social:
+      - icon: fontawesome/brands/github
+        link: 'https://github.com/gleitz/howdoi'


### PR DESCRIPTION
I added the basic MKDocs setup files along with some examples of the features you can use like tooltips, code blocks etc. This isn't meant to be a finished product it's mainly a preview as to what MKDocs looks like and how to use the various features and extensions that it has.

The commands you need to use it are
`pip install mkdocs-material markdown-include`
and
`python -m mkdocs serve` - Start the live-reloading docs server.
`python -m mkdocs build` - Build the documentation site.
`python -m mkdocs help` - Print this help message

At the moment there is no live buiilding and serving of the docs on commits as there would be with the github actions setup for it. I took some inspiration from [Typer's](https://github.com/tiangolo/typer) use of MKDocs so if you'd like to get that setup it'd be a good place to get started from in terms of seeing how it all works.

[Here](https://mlh-fellowship.github.io/howdoi/)'s the live version of the docs.

