### PR TITLE
Change test teardown methods

### DIFF
--- a/test_howdoi.py
+++ b/test_howdoi.py
@@ -54,8 +54,10 @@ class HowdoiTestCase(unittest.TestCase):
         self.assertTrue(len(res) > 0)
 
     def tearDown(self):
-        os.environ['HOWDOI_URL'] = ''
-        os.environ['HOWDOI_SEARCH_ENGINE'] = ''
+        keys_to_remove = ['HOWDOI_URL', 'HOWDO_SEARCH_ENGINE']
+        for key in keys_to_remove:
+            if key in os.environ:
+                del os.environ[key]
 
     def test_get_link_at_pos(self):
         self.assertEqual(howdoi.get_link_at_pos(['/questions/42/'], 1),

--- a/test_howdoi.py
+++ b/test_howdoi.py
@@ -54,7 +54,8 @@ class HowdoiTestCase(unittest.TestCase):
         self.assertTrue(len(res) > 0)
 
     def tearDown(self):
-        time.sleep(2)
+        os.environ['HOWDOI_URL'] = ''
+        os.environ['HOWDOI_SEARCH_ENGINE'] = ''
 
     def test_get_link_at_pos(self):
         self.assertEqual(howdoi.get_link_at_pos(['/questions/42/'], 1),


### PR DESCRIPTION
@gleitz This replaces the teardown method with deleting the keys from the os.environ object. it's important to check if the key exists before attempting to delete because the env variable may not be set.