### PR TITLE
Fixed keep initialization

### DIFF
--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -508,8 +508,13 @@ def _stash_remove(cmd_key, title):
 
 
 def _stash_save(cmd_key, title, answer):
-    keep_utils.save_command(cmd_key, answer, title)
-    print_stash()
+    try:
+        keep_utils.save_command(cmd_key, answer, title)
+    except FileNotFoundError:
+        os.system('keep init')
+        keep_utils.save_command(cmd_key, answer, title)
+    finally:
+        print_stash()
 
 
 def _parse_cmd(args, res):


### PR DESCRIPTION
Addresses #297.

Simple check to see if a `FileNotFoundError` exception would be thrown or not. If thrown, we know the user did not initialize `.keep/` so we run `keep init` to initialize the environment for them. After we do this, we save their query.

If a `FileNotFoundError` exception is not thrown, then we're good to go.