### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,17 @@ matrix:
     - python: "3.8"
       dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
       sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
+    #powerjobs
+    - python: "3.5"
+      arch: ppc64le
+    - python: "3.6"
+      arch: ppc64le
+    - python: "3.7"
+      arch: ppc64le
+    - python: "3.8"
+      arch: ppc64le
+      dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+      sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)    
 
 # command to install dependencies
 install: "pip install -r requirements.txt"


### PR DESCRIPTION
Thank you for the code.
Add support for architecture ppc64le.  
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3
