### PR TITLE
add sanity check

### DIFF
--- a/howdoi/errors.py
+++ b/howdoi/errors.py
@@ -1,0 +1,8 @@
+class GoogleValidationError(Exception):
+    pass
+
+class BingValidationError(Exception):
+    pass
+
+class DDGValidationError(Exception):
+    pass

--- a/howdoi/errors.py
+++ b/howdoi/errors.py
@@ -1,8 +1,10 @@
 class GoogleValidationError(Exception):
     pass
 
+
 class BingValidationError(Exception):
     pass
+
 
 class DDGValidationError(Exception):
     pass

--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -39,6 +39,7 @@ from requests.exceptions import SSLError
 from howdoi import __version__
 from howdoi.errors import GoogleValidationError, BingValidationError, DDGValidationError
 
+
 # rudimentary standardized 3-level log output
 def _print_err(err):
     print("[ERROR] " + err)
@@ -640,7 +641,7 @@ def get_parser():
     return parser
 
 
-def sanity_check(test_query=None):
+def _sanity_check(test_query=None):
     parser = get_parser()
     if not test_query:
         test_query = 'format date bash'
@@ -650,7 +651,7 @@ def sanity_check(test_query=None):
         _print_ok('Cache cleared successfully')
     else:
         _print_err('Clearing cache failed')
-    
+
     google_args = vars(parser.parse_args(test_query))
     google_args['search_engine'] = 'google'
 
@@ -677,6 +678,7 @@ def sanity_check(test_query=None):
         assert howdoi(ddg_args).encode('utf-8', 'ignore') != error_result
     except Exception:
         raise DDGValidationError
+
 
 def prompt_stash_remove(args, stash_list, view_stash=True):
     if view_stash:
@@ -709,12 +711,31 @@ def prompt_stash_remove(args, stash_list, view_stash=True):
         return
 
 
+def perform_sanity_check():
+    try:
+        _sanity_check()
+    except GoogleValidationError:
+        _print_err('Google query failed')
+        return
+    except BingValidationError:
+        _print_err('Bing query failed')
+        return
+    except DDGValidationError:
+        _print_err('DuckDuckGo query failed')
+        return
+    print('Ok')
+
+
 def command_line_runner():  # pylint: disable=too-many-return-statements,too-many-branches
     parser = get_parser()
     args = vars(parser.parse_args())
 
     if args['version']:
         _print_ok(__version__)
+        return
+
+    if args['sanity_check']:
+        perform_sanity_check()
         return
 
     if args['clear_cache']:

--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -664,20 +664,20 @@ def _sanity_check(test_query=None):
     # Validate Google
     try:
         assert howdoi(google_args).encode('utf-8', 'ignore') != error_result
-    except Exception:
-        raise GoogleValidationError
+    except AssertionError as exc:
+        raise GoogleValidationError from exc
 
     # Validate Bing
     try:
         assert howdoi(bing_args).encode('utf-8', 'ignore') != error_result
-    except Exception:
-        raise BingValidationError
+    except AssertionError as exc:
+        raise BingValidationError from exc
 
     # Validate DuckDuckGo
     try:
         assert howdoi(ddg_args).encode('utf-8', 'ignore') != error_result
-    except Exception:
-        raise DDGValidationError
+    except AssertionError as exc:
+        raise DDGValidationError from exc
 
 
 def prompt_stash_remove(args, stash_list, view_stash=True):

--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -712,18 +712,22 @@ def prompt_stash_remove(args, stash_list, view_stash=True):
 
 
 def perform_sanity_check():
+    '''Perform sanity check.
+    Returns exit code for program. An exit code of -1 means a validation error was encountered.
+    '''
     try:
         _sanity_check()
     except GoogleValidationError:
         _print_err('Google query failed')
-        return
+        return -1
     except BingValidationError:
         _print_err('Bing query failed')
-        return
+        return -1
     except DDGValidationError:
         _print_err('DuckDuckGo query failed')
-        return
+        return -1
     print('Ok')
+    return 0
 
 
 def command_line_runner():  # pylint: disable=too-many-return-statements,too-many-branches
@@ -735,8 +739,9 @@ def command_line_runner():  # pylint: disable=too-many-return-statements,too-man
         return
 
     if args['sanity_check']:
-        perform_sanity_check()
-        return
+        sys.exit(
+            perform_sanity_check()
+        )
 
     if args['clear_cache']:
         if _clear_cache():

--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -640,6 +640,31 @@ def get_parser():
     return parser
 
 
+def sanity_check():
+    parser = get_parser()
+    test_query = 'format date bash'
+    error_result = b"Sorry, couldn't find any help with that topic\n"
+
+    if _clear_cache():
+        _print_ok('Cache cleared successfully')
+    else:
+        _print_err('Clearing cache failed')
+    
+    google_args = vars(parser.parse_args(test_query))
+    google_args['search_engine'] = 'google'
+
+    bing_args = vars(parser.parse_args(test_query))
+    bing_args['search_engine'] = 'bing'
+
+    ddg_args = vars(parser.parse_args(test_query))
+    ddg_args['search_engine'] = 'duckduckgo'
+
+
+    assert howdoi(google_args).encode('utf-8', 'ignore') != error_result
+    assert howdoi(bing_args).encode('utf-8', 'ignore') != error_result
+    assert howdoi(ddg_args).encode('utf-8', 'ignore') != error_result
+
+
 def prompt_stash_remove(args, stash_list, view_stash=True):
     if view_stash:
         print_stash(stash_list)
@@ -674,7 +699,8 @@ def prompt_stash_remove(args, stash_list, view_stash=True):
 def command_line_runner():  # pylint: disable=too-many-return-statements,too-many-branches
     parser = get_parser()
     args = vars(parser.parse_args())
-
+    sanity_check()
+    return
     if args['version']:
         _print_ok(__version__)
         return

--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -635,6 +635,8 @@ def get_parser():
                         action='store_true')
     parser.add_argument('--empty', help='empty your stash',
                         action='store_true')
+    parser.add_argument('--sanity-check', help='perform a sanity check to verify if howdoi is working fine',
+                        action='store_true')
     return parser
 
 


### PR DESCRIPTION
Adds a `--sanity-check` flag to howdoi that checks if a standard query ("format date bash") works or fails on all currently supported engines. 
Implements the first feature in the checklist at #337 