### PR TITLE
use duckduckgo no-javascript version directly

### DIFF
--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -77,7 +77,7 @@ USER_AGENTS = ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:11.0) Gecko/2010
 SEARCH_URLS = {
     'bing': SCHEME + 'www.bing.com/search?q=site:{0}%20{1}&hl=en',
     'google': SCHEME + 'www.google.com/search?q=site:{0}%20{1}&hl=en',
-    'duckduckgo': SCHEME + 'duckduckgo.com/?q=site:{0}%20{1}&t=hj&ia=web'
+    'duckduckgo': SCHEME + 'duckduckgo.com/html?q=site:{0}%20{1}&t=hj&ia=web'
 }
 
 BLOCK_INDICATORS = (


### PR DESCRIPTION
 to avoid redirection failing sometimes.

close #368 