### PR TITLE
Explainability

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 # howdoi
-Never have open your browser to look for answers again.
+Never have to open your browser to look for answers again.
 
 Create tar archive:
 ```bash

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,6 +1,6 @@
 ## Usage
 
-If that's your first time using howdoi, run the quick help
+If it's your first time using howdoi, run the quick help
 
 ```bash
 $ howdoi howdoi

--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -595,7 +595,10 @@ def howdoi(raw_query):
     try:
         res = _get_answers(args)
         if not res:
-            res = {'error': 'Sorry, couldn\'t find any help with that topic\n(use --explain to learn why)'}
+            if '--explain' in raw_query.split(' '):
+                res = {'error': 'Sorry, couldn\'t find any help with that topic'}
+            else:
+                res = {'error': 'Sorry, couldn\'t find any help with that topic\n(use --explain to learn why)'}
         cache.set(cache_key, res)
     except (RequestsConnectionError, SSLError):
         res = {'error': 'Unable to reach {search_engine}. Do you need to use a proxy?\n'.format(

--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -595,7 +595,7 @@ def howdoi(raw_query):
     try:
         res = _get_answers(args)
         if not res:
-            if '--explain' in raw_query.split(' '):
+            if raw_query['explain']:
                 res = {'error': 'Sorry, couldn\'t find any help with that topic'}
             else:
                 res = {'error': 'Sorry, couldn\'t find any help with that topic\n(use --explain to learn why)'}


### PR DESCRIPTION
Three changes, two of them are simple, small typos in the index.md and user-guide.md.
The third is changing how the error message throws "(use --explain to learn why)", previously it threw it in all cases where "Sorry, couldn't find any help with with that topic", now it only throws it if you're not already using "--explain".