### PR TITLE
GDPR fix for Google?

### DIFF
--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -176,7 +176,8 @@ def _get_result(url):
     try:
         resp = howdoi_session.get(url, headers={'User-Agent': _random_choice(USER_AGENTS)},
                                   proxies=get_proxies(),
-                                  verify=VERIFY_SSL_CERTIFICATE)
+                                  verify=VERIFY_SSL_CERTIFICATE,
+                                  cookies={'CONSENT':'YES+US.en+20170717-00-0'})
         resp.raise_for_status()
         return resp.text
     except requests.exceptions.SSLError as error:


### PR DESCRIPTION
The only problem for European users was the GDPR splash screen that Google was showing. Adding a small cookie jar onto our request may fix all of that. Seems to work for me.