### PR TITLE
Search engine fallbacks - including test 

### DIFF
--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -591,8 +591,8 @@ def howdoi(raw_query):
     else:
         args = raw_query
 
-    os.environ['HOWDOI_SEARCH_ENGINE'] = args['search_engine'] or os.getenv('HOWDOI_SEARCH_ENGINE') or 'google'
-    search_engine = os.getenv('HOWDOI_SEARCH_ENGINE')
+    search_engine = args['search_engine'] or os.getenv('HOWDOI_SEARCH_ENGINE') or 'google'
+    os.environ['HOWDOI_SEARCH_ENGINE'] = search_engine
     if search_engine not in SUPPORTED_SEARCH_ENGINES:
         supported_search_engines = ', '.join(SUPPORTED_SEARCH_ENGINES)
         message = f'Unsupported engine {search_engine}. The supported engines are: {supported_search_engines}'
@@ -622,9 +622,9 @@ def howdoi(raw_query):
             res = {'error': message}
         cache.set(cache_key, res)
     except (RequestsConnectionError, SSLError):
-        res = {'error': f'Unable to reach {args["search_engine"]}. Do you need to use a proxy?\n'}
+        res = {'error': f'Unable to reach {search_engine}. Do you need to use a proxy?\n'}
     except BlockError:
-        BLOCKED_ENGINES.append(args['search_engine'])
+        BLOCKED_ENGINES.append(search_engine)
         next_engine = next((engine for engine in SUPPORTED_SEARCH_ENGINES if engine not in BLOCKED_ENGINES), None)
         if next_engine is None:
             res = {'error': 'Unable to get a response from any search engine\n'}

--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -626,7 +626,7 @@ def howdoi(raw_query):
     except BlockError:
         BLOCKED_ENGINES.append(args['search_engine'])
         if BLOCKED_ENGINES == SUPPORTED_SEARCH_ENGINES:
-            return
+            return howdoi(args)
         for eng in SUPPORTED_SEARCH_ENGINES:
             if eng not in BLOCKED_ENGINES:
                 logging.error('%sRetrying search with %s%s', GREEN, eng, END_FORMAT)

--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -586,7 +586,8 @@ def _parse_cmd(args, res):
 
 def howdoi(raw_query):
     if isinstance(raw_query['query'], str):  # you can pass either a raw or a parsed query
-        raw_query['query'] = raw_query['query'].split(' ')
+        split_query = raw_query['query'].split(' ')
+        raw_query['query'] = split_query
     args = raw_query
 
     os.environ['HOWDOI_SEARCH_ENGINE'] = args['search_engine'] or os.getenv('HOWDOI_SEARCH_ENGINE') or 'google'

--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -623,12 +623,12 @@ def howdoi(raw_query):
         res = {'error': f'Unable to reach {args["search_engine"]}. Do you need to use a proxy?\n'}
     except BlockError:
         BLOCKED_ENGINES.append(args['search_engine'])
-        next_engine = next((engine for engine in SUPPORTED_SEARCH_ENGINES if engine not in BLOCKED_ENGINES), None) 
-        if next_engine is None:  
+        next_engine = next((engine for engine in SUPPORTED_SEARCH_ENGINES if engine not in BLOCKED_ENGINES), None)
+        if next_engine is None:
             logging.info('%sAll search engines failed.%s', RED, END_FORMAT)
-        else:        
+        else:
             args['search_engine'] = next_engine
-            logging.error('%sRetrying search with %s%s', GREEN, next_engine, END_FORMAT)     
+            logging.error('%sRetrying search with %s%s', GREEN, next_engine, END_FORMAT)
             return howdoi(args)
     return _parse_cmd(args, res)
 

--- a/test_howdoi.py
+++ b/test_howdoi.py
@@ -6,7 +6,12 @@ import json
 import os
 import re
 import unittest
+
+import requests
+
 from pathlib import Path
+from unittest.mock import patch
+
 from cachelib import NullCache
 from pyquery import PyQuery as pq
 
@@ -15,21 +20,56 @@ from howdoi import howdoi
 
 
 # pylint: disable=protected-access
-class HowdoiTestCase(unittest.TestCase):  # pylint: disable=too-many-public-methods
-    def _get_result_mock(self, url):
-        file_name = howdoi._format_url_to_filename(url, 'html.gz')
-        # pylint: disable=no-member
-        file_path = Path.joinpath(Path(howdoi.HTML_CACHE_PATH), Path(file_name)).resolve()
-        try:
-            with gzip.open(file_path, 'rb') as f:
-                cached_page_content = str(f.read(), encoding='utf-8')
-                return cached_page_content
+original_get_result = howdoi._get_result
 
-        except FileNotFoundError:
-            page_content = self.original_get_result(url)
-            with gzip.open(file_path, 'wb') as f:
-                f.write(bytes(page_content, encoding='utf-8'))
-                return page_content
+
+def _get_result_mock(url):
+    # pylint: disable=protected-access
+    file_name = howdoi._format_url_to_filename(url, 'html.gz')
+    # pylint: disable=no-member
+    file_path = Path.joinpath(Path(howdoi.HTML_CACHE_PATH), Path(file_name)).resolve()
+    try:
+        with gzip.open(file_path, 'rb') as f:
+            cached_page_content = str(f.read(), encoding='utf-8')
+            return cached_page_content
+
+    except FileNotFoundError:
+        page_content = original_get_result(url)
+        with gzip.open(file_path, 'wb') as f:
+            f.write(bytes(page_content, encoding='utf-8'))
+            return page_content
+
+
+# pylint: disable=protected-access
+class HowdoiTestCase(unittest.TestCase):  # pylint: disable=too-many-public-methods
+
+    def setUp(self):
+        self.patcher_get_result = patch.object(howdoi, '_get_result')
+        self.mock_get_result = self.patcher_get_result.start()
+        self.mock_get_result.side_effect = _get_result_mock
+        # ensure no cache is used during testing.
+        howdoi.cache = NullCache()
+
+        self.queries = ['format date bash',
+                        'print stack trace python',
+                        'convert mp4 to animated gif',
+                        'create tar archive',
+                        'cat']
+        self.help_queries = howdoi.SUPPORTED_HELP_QUERIES
+        self.pt_queries = ['abrir arquivo em python',
+                           'enviar email em django',
+                           'hello world em c']
+        self.bad_queries = ['moe',
+                            'mel']
+        self.query_without_code_or_pre_block = 'Difference between element node and Text Node'
+
+    def tearDown(self):
+        self.patcher_get_result.stop()
+        keys_to_remove = ['HOWDOI_URL', 'HOWDOI_SEARCH_ENGINE']
+        for key in keys_to_remove:
+            if key in os.environ:
+                del os.environ[key]
+        howdoi.BLOCKED_ENGINES = []
 
     def _negative_number_query(self):
         query = self.queries[0]
@@ -47,38 +87,8 @@ class HowdoiTestCase(unittest.TestCase):  # pylint: disable=too-many-public-meth
         query = self.queries[0]
         howdoi.howdoi(query + ' -p 40')
 
-    @classmethod
-    def _get_links_blockerror(cls, query):
-        raise howdoi.BlockError
-
-    def setUp(self):
-        self.original_get_result = howdoi._get_result
-        howdoi._get_result = self._get_result_mock
-
-        # ensure no cache is used during testing.
-        howdoi.cache = NullCache()
-
-        self.queries = ['format date bash',
-                        'print stack trace python',
-                        'convert mp4 to animated gif',
-                        'create tar archive',
-                        'cat']
-        self.help_queries = howdoi.SUPPORTED_HELP_QUERIES
-        self.pt_queries = ['abrir arquivo em python',
-                           'enviar email em django',
-                           'hello world em c']
-        self.bad_queries = ['moe',
-                            'mel']
-        self.query_without_code_or_pre_block = 'Difference between element node and Text Node'
-
     def assertValidResponse(self, res):  # pylint: disable=invalid-name
         self.assertTrue(len(res) > 0)
-
-    def tearDown(self):
-        keys_to_remove = ['HOWDOI_URL', 'HOWDO_SEARCH_ENGINE']
-        for key in keys_to_remove:
-            if key in os.environ:
-                del os.environ[key]
 
     def test_get_link_at_pos(self):
         self.assertEqual(howdoi.get_link_at_pos(['/questions/42/'], 1),
@@ -91,6 +101,13 @@ class HowdoiTestCase(unittest.TestCase):  # pylint: disable=too-many-public-meth
                          '/questions/42/')
         self.assertEqual(howdoi.get_link_at_pos(['/questions/42/', '/questions/142/'], 1),
                          '/questions/42/')
+
+    @patch.object(howdoi, '_get_result')
+    def test_blockerror(self, mock_get_links):
+        mock_get_links.side_effect = requests.HTTPError
+        query = self.queries[0]
+        response = howdoi.howdoi(query)
+        self.assertEqual(response, "ERROR: \x1b[91mUnable to get a response from any search engine\n\x1b[0m")
 
     def test_answers(self):
         for query in self.queries:
@@ -282,12 +299,6 @@ class HowdoiTestCase(unittest.TestCase):  # pylint: disable=too-many-public-meth
             self._high_positive_position_query()
         with self.assertRaises(SystemExit):
             self._high_positive_number_query()
-
-    def test_sample(self):
-        query = self.queries[0]
-        howdoi._get_links = self._get_links_blockerror
-        response = howdoi.howdoi(query)
-        self.assertEqual(response, "ERROR: \x1b[91mUnable to get a response from any search engine\n\x1b[0m")
 
 
 class HowdoiTestCaseEnvProxies(unittest.TestCase):

--- a/test_howdoi.py
+++ b/test_howdoi.py
@@ -287,7 +287,7 @@ class HowdoiTestCase(unittest.TestCase):  # pylint: disable=too-many-public-meth
         query = self.queries[0]
         howdoi._get_links = self._get_links_blockerror
         response = howdoi.howdoi(query)
-        self.assertEqual(response,"ERROR: \x1b[91mUnable to get a response from any search engine\n\x1b[0m")
+        self.assertEqual(response, "ERROR: \x1b[91mUnable to get a response from any search engine\n\x1b[0m")
 
 class HowdoiTestCaseEnvProxies(unittest.TestCase):
 

--- a/test_howdoi.py
+++ b/test_howdoi.py
@@ -7,10 +7,9 @@ import os
 import re
 import unittest
 
-import requests
-
 from pathlib import Path
 from unittest.mock import patch
+import requests
 
 from cachelib import NullCache
 from pyquery import PyQuery as pq

--- a/test_howdoi.py
+++ b/test_howdoi.py
@@ -47,6 +47,10 @@ class HowdoiTestCase(unittest.TestCase):  # pylint: disable=too-many-public-meth
         query = self.queries[0]
         howdoi.howdoi(query + ' -p 40')
 
+    def _get_links_blockerror(self, query):
+        # print("raising error")
+        raise howdoi.BlockError
+
     def setUp(self):
         self.original_get_result = howdoi._get_result
         howdoi._get_result = self._get_result_mock
@@ -279,6 +283,11 @@ class HowdoiTestCase(unittest.TestCase):  # pylint: disable=too-many-public-meth
         with self.assertRaises(SystemExit):
             self._high_positive_number_query()
 
+    def test_sample(self):
+        query = self.queries[0]
+        howdoi._get_links = self._get_links_blockerror
+        response = howdoi.howdoi(query)
+        self.assertEqual(response,"ERROR: \x1b[91mUnable to get a response from any search engine\n\x1b[0m")
 
 class HowdoiTestCaseEnvProxies(unittest.TestCase):
 

--- a/test_howdoi.py
+++ b/test_howdoi.py
@@ -47,8 +47,8 @@ class HowdoiTestCase(unittest.TestCase):  # pylint: disable=too-many-public-meth
         query = self.queries[0]
         howdoi.howdoi(query + ' -p 40')
 
-    def _get_links_blockerror(self, query):
-        # print("raising error")
+    @classmethod
+    def _get_links_blockerror(cls, query):
         raise howdoi.BlockError
 
     def setUp(self):

--- a/test_howdoi.py
+++ b/test_howdoi.py
@@ -289,6 +289,7 @@ class HowdoiTestCase(unittest.TestCase):  # pylint: disable=too-many-public-meth
         response = howdoi.howdoi(query)
         self.assertEqual(response, "ERROR: \x1b[91mUnable to get a response from any search engine\n\x1b[0m")
 
+
 class HowdoiTestCaseEnvProxies(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Addresses issue #407 . 

Fallbacks in case of search engine failure: iterates through the supported engines to find a search engine that has not been blocked. If all supported engines are blocked, it simply returns. 

![image](https://user-images.githubusercontent.com/68891347/126169645-cc11d1c0-9090-49b0-8e95-030b3381a351.png)
