### PR TITLE
Workaround FileNotFoundError thrown by cachelib

### DIFF
--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -341,7 +341,11 @@ def _get_questions(links):
 
 def _get_answer(args, link):  # pylint: disable=too-many-branches
     cache_key = _get_cache_key(link)
-    page = cache.get(cache_key)  # pylint: disable=assignment-from-none
+    try:
+        # The cache should already be None if not found by cachelib, but as of cachelib 0.3.0 it is giving a FileNotFoundError
+        page = cache.get(cache_key)  # pylint: disable=assignment-from-none
+    except FileNotFoundError:
+        page = None
     if not page:
         logging.info('Fetching page: %s', link)
         page = _get_result(link + '?answertab=votes')

--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -342,7 +342,7 @@ def _get_questions(links):
 def _get_answer(args, link):  # pylint: disable=too-many-branches
     cache_key = _get_cache_key(link)
     try:
-        # The cache should already be None if not found by cachelib, but as of cachelib 0.3.0 it is giving a FileNotFoundError
+        # As of cachelib 0.3.0, it is throwing a FileNotFoundError exception on cache miss
         page = cache.get(cache_key)  # pylint: disable=assignment-from-none
     except FileNotFoundError:
         page = None


### PR DESCRIPTION
Closes #420 

Works around cachelib throwing a FileNotFoundError on cache misses. Updating to the latest version of cachelib did not seem to resolve the issue, so this seems to be the best solution for now.