### PR TITLE
Drop python2 support in command_line_runner

### DIFF
--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -812,12 +812,9 @@ def command_line_runner():  # pylint: disable=too-many-return-statements,too-man
     if os.getenv('HOWDOI_COLORIZE'):
         args['color'] = True
 
-    utf8_result = howdoi(args).encode('utf-8', 'ignore')
-    if sys.version < '3':
-        print(utf8_result)
-    else:
-        # Write UTF-8 to stdout: https://stackoverflow.com/a/3603160
-        sys.stdout.buffer.write(utf8_result)
+    result = howdoi(args)
+    print(result)
+
     # close the session to release connection
     howdoi_session.close()
 

--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -812,8 +812,9 @@ def command_line_runner():  # pylint: disable=too-many-return-statements,too-man
     if os.getenv('HOWDOI_COLORIZE'):
         args['color'] = True
 
-    result = howdoi(args)
-    print(result)
+    utf8_result = howdoi(args).encode('utf-8', 'ignore')
+    # Write UTF-8 to stdout: https://stackoverflow.com/a/3603160
+    sys.stdout.buffer.write(utf8_result)
 
     # close the session to release connection
     howdoi_session.close()


### PR DESCRIPTION
This PR is related to #426 

- removed if statement for checking python version
- removed utf-8 encoding

close #426