### PR TITLE
updated import path in main.py

### DIFF
--- a/howdoi/__main__.py
+++ b/howdoi/__main__.py
@@ -1,3 +1,3 @@
-from .howdoi import command_line_runner
+from howdoi.howdoi import command_line_runner
 
 command_line_runner()


### PR DESCRIPTION
fixes #434 

I have changed explicit relative import to absolute import statement. `pylint 2.8.2` (which is configured for pre-commit) did not give any warning/error for relative import statement but `pylint 2.11.1` is giving error, not sure why.