### PR TITLE
Fix Python version for the early warning system.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,8 @@ jobs:
 
     - name: Set up Python
       uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
 
     - name: Install Pip
       run:  python -m pip install --upgrade pip

--- a/.github/workflows/early-warning.yml
+++ b/.github/workflows/early-warning.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
 
       - name: Setup environment
         run: pip install -r requirements.txt

--- a/.github/workflows/python-non-master.yml
+++ b/.github/workflows/python-non-master.yml
@@ -27,8 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 nose pylint
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        if [ -f requirements/dev.txt ]; then pip install -r requirements/dev.txt; fi
     - name: Lint with flake8
       run: |
         flake8 . --count --show-source --statistics

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -23,8 +23,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 nose pylint
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        if [ -f requirements/dev.txt ]; then pip install -r requirements/dev.txt; fi
     - name: Lint with flake8
       run: |
         flake8 . --count --show-source --statistics

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,6 @@
 # Contains development specific requirements and imports common requirements
 flake8==3.9.2
+nose==1.3.7
 pylint==2.11.1
 pre-commit==2.13.0
 twine==3.4.1


### PR DESCRIPTION
Was getting this error on Python 3.10 for pathlib:

```
ImportError: cannot import name 'Sequence' from 'collections'
```

## Description:

See this error https://github.com/gleitz/howdoi/runs/4003727061?check_suite_focus=true

## Pull Request type:

- Bug fixes

## How to test:

All Github actions should run properly
