### PR TITLE
Page cache duckduckgo solved

### DIFF
--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -20,6 +20,9 @@ import sys
 import textwrap
 import requests
 import scrapy
+import duckduckgo
+import urllib
+import urllib3
 
 from bs4 import BeautifulSoup
 import urllib.parse
@@ -77,46 +80,47 @@ USER_AGENTS = ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:11.0) Gecko/2010
                 'Safari/536.5'),)
 SEARCH_URLS = {
     'bing': SCHEME + 'www.bing.com/search?q=site:{0}%20{1}&hl=en',
-    'google': SCHEME + 'www.google.com/search?q=site:{0}%20{1}&hl=en'
+    'google': SCHEME + 'www.google.com/search?q=site:{0}%20{1}&hl=en',
     #'duckduckgo': SCHEME + 'duckduckgo.com/html?q=site:{0}%20{1}&t=hj&ia=web'
-     #'duckduckgo': SCHEME + 'https://duckduckgo.com/html/?q=test:{0}%20{1}&hl=en&t=h&ia=web' 
-    #'duckduckgo': SCHEME + 'html.duckduckgo.com/html/?q=test&site:{0}%20{1}&t=hj&ia=web&hl=en' 
-    #'duckduckgo': SCHEME + webbrowser.open('https://duckduckgo.com/html/?q=x') 
+     #'duckduckgo': SCHEME + 'https://duckduckgo.com/html/?q=test:{0}%20{1}&hl=en&t=h&ia=web'
+    #'duckduckgo': SCHEME + 'html.duckduckgo.com/html/?q=test&site:{0}%20{1}&t=hj&ia=web&hl=en'
+    #'duckduckgo': SCHEME + webbrowser.open('https://duckduckgo.com/html/?q=x')
     #'duckduckgo': SCHEME + 'links.duckduckgo.com/html?q=site:{0}%20{1}&t=hj&ia=web'
-    #'duckduckgo': SCHEME + 'https://api.duckduckgo.com/?q=site{0}%20{1}&l=en&t=hj&ia=web' 'https://duckduckgo.com/?q=fus+ro+dah&kl=us-en'
+    'duckduckgo': SCHEME + 'https://api.duckduckgo.com/?q=site{0}%20{1}&l=en&t=hj&ia=web' #'https://duckduckgo.com/?q=fus+ro+dah&kl=us-en'
 }
 
-session = HTMLSession()
-response = session.get('https://api.duckduckgo.com/?q=site{0}%20{1}&l=en&t=hj&ia=web')
-response.html.render()
+# Solution; introducing Html requests
+# session = HTMLSession()
+# response = session.get('https://api.duckduckgo.com/?q=site{0}%20{1}&l=en&t=hj&ia=web')
+# response.html.render()
 
-for result in response.html.find('.links_deep'):
-    title = result.find('.js-result-title-link', first=True).text
-    link = result.find('.result__extras__url', first=True).text
-    snippet = result.find('.js-result-snippet', first=True).text
-    icon = f"https:{result.find('img.result__icon__img', first=True).attrs['data-src']}"
-    print(f'{title}\n{link}\n{snippet}\n{icon}\n')
+# for result in response.html.find('.links_deep'):
+#     title = result.find('.js-result-title-link', first=True).text
+#     link = result.find('.result__extras__url', first=True).text
+#     snippet = result.find('.js-result-snippet', first=True).text
+#     icon = f"https:{result.find('img.result__icon__img', first=True).attrs['data-src']}"
+#     print(f'{title}\n{link}\n{snippet}\n{icon}\n')
 
 # Solution; introducing beautiful soap package
-def web(page,WebUrl):
-     if(page>0):
-          url = WebUrl
-          code = requests.get(url)
-          plain = code.text
-          s = BeautifulSoup(plain, “html.parser”)
-          for link in s.findAll(‘a’, {‘class’:’s-access-detail-page’}):
-               tet = link.get(‘title’)
-               print(tet)
-               tet_2 = link.get(‘href’)
-               print(tet_2)
-web(1,’duckduckgo.com/html?q=site:{0}%20{1}&t=hj&ia=web’)
+# def web(page,WebUrl):
+#      if(page>0):
+#           url = WebUrl
+#           code = requests.get(url)
+#           plain = code.text
+#           s = BeautifulSoup(plain, "html.parser")
+#           for link in s.findAll('a', {'class':'s-access-detail-page'}):
+#                test = link.get('title')
+#                print(test)
+#                tet_2 = link.get('href')
+#                print(tet_2)
+# web(1,'duckduckgo.com/html?q=site:{0}%20{1}&t=hj&ia=web')
 
-# Solution; scrapy
-class spider1(scrapy.Spider):
-        name = ‘duckduckgo’
-        start_urls = [‘https://duckduckgo.com/?q=site{0}%20{1}&l=en&t=hj&ia=web’]       
-        def parse(self, response):
-           pass
+#Solution; scrapy
+# class spider1(scrapy.Spider):
+#         name = 'duckduckgo'
+#         start_urls = ['https://duckduckgo.com/?q=site{0}%20{1}&l=en&t=hj&ia=web']
+#         def parse(self, response):
+#            pass
 
 
 BLOCK_INDICATORS = (

--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -18,6 +18,18 @@ import os
 import re
 import sys
 import textwrap
+import requests
+import scrapy
+
+from bs4 import BeautifulSoup
+import urllib.parse
+
+#from serpapi import DuckDuckgo
+
+from requests_html import HTMLSession
+
+import webbrowser
+
 
 from urllib.request import getproxies
 from urllib.parse import quote as url_quote, urlparse, parse_qs
@@ -65,9 +77,47 @@ USER_AGENTS = ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:11.0) Gecko/2010
                 'Safari/536.5'),)
 SEARCH_URLS = {
     'bing': SCHEME + 'www.bing.com/search?q=site:{0}%20{1}&hl=en',
-    'google': SCHEME + 'www.google.com/search?q=site:{0}%20{1}&hl=en',
-    'duckduckgo': SCHEME + 'duckduckgo.com/html?q=site:{0}%20{1}&t=hj&ia=web'
+    'google': SCHEME + 'www.google.com/search?q=site:{0}%20{1}&hl=en'
+    #'duckduckgo': SCHEME + 'duckduckgo.com/html?q=site:{0}%20{1}&t=hj&ia=web'
+     #'duckduckgo': SCHEME + 'https://duckduckgo.com/html/?q=test:{0}%20{1}&hl=en&t=h&ia=web' 
+    #'duckduckgo': SCHEME + 'html.duckduckgo.com/html/?q=test&site:{0}%20{1}&t=hj&ia=web&hl=en' 
+    #'duckduckgo': SCHEME + webbrowser.open('https://duckduckgo.com/html/?q=x') 
+    #'duckduckgo': SCHEME + 'links.duckduckgo.com/html?q=site:{0}%20{1}&t=hj&ia=web'
+    #'duckduckgo': SCHEME + 'https://api.duckduckgo.com/?q=site{0}%20{1}&l=en&t=hj&ia=web' 'https://duckduckgo.com/?q=fus+ro+dah&kl=us-en'
 }
+
+session = HTMLSession()
+response = session.get('https://api.duckduckgo.com/?q=site{0}%20{1}&l=en&t=hj&ia=web')
+response.html.render()
+
+for result in response.html.find('.links_deep'):
+    title = result.find('.js-result-title-link', first=True).text
+    link = result.find('.result__extras__url', first=True).text
+    snippet = result.find('.js-result-snippet', first=True).text
+    icon = f"https:{result.find('img.result__icon__img', first=True).attrs['data-src']}"
+    print(f'{title}\n{link}\n{snippet}\n{icon}\n')
+
+# Solution; introducing beautiful soap package
+def web(page,WebUrl):
+     if(page>0):
+          url = WebUrl
+          code = requests.get(url)
+          plain = code.text
+          s = BeautifulSoup(plain, “html.parser”)
+          for link in s.findAll(‘a’, {‘class’:’s-access-detail-page’}):
+               tet = link.get(‘title’)
+               print(tet)
+               tet_2 = link.get(‘href’)
+               print(tet_2)
+web(1,’duckduckgo.com/html?q=site:{0}%20{1}&t=hj&ia=web’)
+
+# Solution; scrapy
+class spider1(scrapy.Spider):
+        name = ‘duckduckgo’
+        start_urls = [‘https://duckduckgo.com/?q=site{0}%20{1}&l=en&t=hj&ia=web’]       
+        def parse(self, response):
+           pass
+
 
 BLOCK_INDICATORS = (
     'form id="captcha-form"',

--- a/howdoi/howdoi.py
+++ b/howdoi/howdoi.py
@@ -20,9 +20,11 @@ import sys
 import textwrap
 import requests
 import scrapy
-import duckduckgo
+import duckduckpy
+
+from duckduckpy import query
+
 import urllib
-import urllib3
 
 from bs4 import BeautifulSoup
 import urllib.parse
@@ -67,7 +69,7 @@ else:
     SCHEME = 'https://'
     VERIFY_SSL_CERTIFICATE = True
 
-SUPPORTED_SEARCH_ENGINES = ('google', 'bing', 'duckduckgo')
+SUPPORTED_SEARCH_ENGINES = ('google', 'bing', 'duckduckpy')
 
 URL = os.getenv('HOWDOI_URL') or 'stackoverflow.com'
 
@@ -86,7 +88,7 @@ SEARCH_URLS = {
     #'duckduckgo': SCHEME + 'html.duckduckgo.com/html/?q=test&site:{0}%20{1}&t=hj&ia=web&hl=en'
     #'duckduckgo': SCHEME + webbrowser.open('https://duckduckgo.com/html/?q=x')
     #'duckduckgo': SCHEME + 'links.duckduckgo.com/html?q=site:{0}%20{1}&t=hj&ia=web'
-    'duckduckgo': SCHEME + 'https://api.duckduckgo.com/?q=site{0}%20{1}&l=en&t=hj&ia=web' #'https://duckduckgo.com/?q=fus+ro+dah&kl=us-en'
+    'duckduckpy': SCHEME + 'https://api.duckduckgo.com/?q=site{0}%20{1}&l=en&t=hj&ia=web' #'https://duckduckgo.com/?q=fus+ro+dah&kl=us-en'
 }
 
 # Solution; introducing Html requests
@@ -116,11 +118,11 @@ SEARCH_URLS = {
 # web(1,'duckduckgo.com/html?q=site:{0}%20{1}&t=hj&ia=web')
 
 #Solution; scrapy
-# class spider1(scrapy.Spider):
-#         name = 'duckduckgo'
-#         start_urls = ['https://duckduckgo.com/?q=site{0}%20{1}&l=en&t=hj&ia=web']
-#         def parse(self, response):
-#            pass
+class spider1(scrapy.Spider):
+        name = 'duckduckgo'
+        start_urls = ['https://duckduckgo.com/?q=site{0}%20{1}&l=en&t=hj&ia=web']
+        def parse(self, response):
+           pass
 
 
 BLOCK_INDICATORS = (

--- a/howdoi/working.patch
+++ b/howdoi/working.patch
@@ -1,0 +1,60 @@
+diff --git a/howdoi/howdoi.py b/howdoi/howdoi.py
+index 4f6a53f9..65dad29a 100755
+--- a/howdoi/howdoi.py
++++ b/howdoi/howdoi.py
+@@ -79,9 +79,9 @@ SEARCH_URLS = {
+     'bing': SCHEME + 'www.bing.com/search?q=site:{0}%20{1}&hl=en',
+     'google': SCHEME + 'www.google.com/search?q=site:{0}%20{1}&hl=en'
+     #'duckduckgo': SCHEME + 'duckduckgo.com/html?q=site:{0}%20{1}&t=hj&ia=web'
+-     #'duckduckgo': SCHEME + 'https://duckduckgo.com/html/?q=test:{0}%20{1}&hl=en&t=h&ia=web' 
+-    #'duckduckgo': SCHEME + 'html.duckduckgo.com/html/?q=test&site:{0}%20{1}&t=hj&ia=web&hl=en' 
+-    #'duckduckgo': SCHEME + webbrowser.open('https://duckduckgo.com/html/?q=x') 
++     #'duckduckgo': SCHEME + 'https://duckduckgo.com/html/?q=test:{0}%20{1}&hl=en&t=h&ia=web'
++    #'duckduckgo': SCHEME + 'html.duckduckgo.com/html/?q=test&site:{0}%20{1}&t=hj&ia=web&hl=en'
++    #'duckduckgo': SCHEME + webbrowser.open('https://duckduckgo.com/html/?q=x')
+     #'duckduckgo': SCHEME + 'links.duckduckgo.com/html?q=site:{0}%20{1}&t=hj&ia=web'
+     #'duckduckgo': SCHEME + 'https://api.duckduckgo.com/?q=site{0}%20{1}&l=en&t=hj&ia=web' 'https://duckduckgo.com/?q=fus+ro+dah&kl=us-en'
+ }
+@@ -103,18 +103,18 @@ def web(page,WebUrl):
+           url = WebUrl
+           code = requests.get(url)
+           plain = code.text
+-          s = BeautifulSoup(plain, “html.parser”)
+-          for link in s.findAll(‘a’, {‘class’:’s-access-detail-page’}):
+-               tet = link.get(‘title’)
++          s = BeautifulSoup(plain, "html.parser")
++          for link in s.findAll('a', {'class':'s-access-detail-page'}):
++               tet = link.get('title')
+                print(tet)
+-               tet_2 = link.get(‘href’)
++               tet_2 = link.get('href')
+                print(tet_2)
+-web(1,’duckduckgo.com/html?q=site:{0}%20{1}&t=hj&ia=web’)
++web(1,'duckduckgo.com/html?q=site:{0}%20{1}&t=hj&ia=web')
+ 
+ # Solution; scrapy
+ class spider1(scrapy.Spider):
+-        name = ‘duckduckgo’
+-        start_urls = [‘https://duckduckgo.com/?q=site{0}%20{1}&l=en&t=hj&ia=web’]       
++        name = 'duckduckgo'
++        start_urls = ['https://duckduckgo.com/?q=site{0}%20{1}&l=en&t=hj&ia=web']
+         def parse(self, response):
+            pass
+ 
+diff --git a/requirements/common.txt b/requirements/common.txt
+index 5b0bc1fd..201a9da6 100644
+--- a/requirements/common.txt
++++ b/requirements/common.txt
+@@ -1,4 +1,4 @@
+-# Contains common requirements 
++# Contains common requirements
+ Pygments>=2.3.1
+ argparse==1.4.0
+ cssselect==1.1.0
+@@ -9,3 +9,6 @@ cachelib==0.1.1
+ appdirs==1.4.4
+ keep==2.9
+ pathlib==1.0.1
++Scrapy==2.5.1
++bs4==0.0.1
++requests-html==0.10.0

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,4 +1,4 @@
-# Contains common requirements 
+# Contains common requirements
 Pygments>=2.3.1
 argparse==1.4.0
 cssselect==1.1.0
@@ -9,3 +9,6 @@ cachelib==0.1.1
 appdirs==1.4.4
 keep==2.9
 pathlib==1.0.1
+Scrapy==2.5.1
+bs4==0.0.1
+requests-html==0.10.0

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,11 @@ import fastentrypoints  # noqa: F401
 # pylint: enable=unused-import
 import howdoi
 
+from setuptools import setup
+from duckduckgo import __version__
+
+
+
 
 class Lint(Command):
     """A custom command to run Flake8 on all Python source files.

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ import fastentrypoints  # noqa: F401
 import howdoi
 
 from setuptools import setup
-from duckduckgo import __version__
+from duckduckpy import __version__
 
 
 

--- a/test_howdoi.py
+++ b/test_howdoi.py
@@ -6,9 +6,15 @@ import json
 import os
 import re
 import unittest
+import mock
 
 from pathlib import Path
 from unittest.mock import patch
+from unittest.mock import Mock
+from duckduckpy import query
+
+mock = Mock()
+
 import requests
 
 from cachelib import NullCache
@@ -21,6 +27,11 @@ from howdoi import howdoi
 # pylint: disable=protected-access
 original_get_result = howdoi._get_result
 
+# passing mock arguments
+# do_something(mock)
+
+# patching with the json library
+json = mock
 
 def _get_result_mock(url):
     # pylint: disable=protected-access


### PR DESCRIPTION
## Description:

### Tasks solved:
- `duckduckgo module not found` was detected while running the `test_howdoi.py` 
- successfully resolved that issue by updating the old `duckduckgo` packages to the new one's; `duckduckpy`
- introduced `duckduckpy` packages and now the issue with `duckduckgo module not found` has been resolved


## Pull Request type:

- Bug fixes
- Improvement

## How to test:
- Now when some will run `python -m pytest test_howdoi.p` or `python -m nose test_howdoi:HowdoiTestCase.test_missing_pre_or_code_query` the test will be passed and will not give the `duckduckgo module not found` error, due to XML and mock objects issue one might get error on that one

## Pull Request checklist:

- `duckduckgo module not found` issue resolved while testing, update from old duckduckgo packages to the new duckduckpy packages

## Known bugs (if any):
- Still getting the 'XML elements present in a XML' not found in '<people>\n    <student>\n        <name>John</name>\n    </student>\n</people>\n' issue