### PR TITLE
Perhaps we do not need pathlib for Python 3.4+

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,7 +23,7 @@ Please provide detailed instructions for testing your changes locally, including
 
 - [ ] Read the [contributing_to_howdoi.md](https://github.com/gleitz/howdoi/blob/master/docs/contributing_to_howdoi.md)
 - [ ] Attach screenshots of expected behavior.
-- [ ] The changes pass tests locally (`nosetests`).
+- [ ] The changes pass tests locally (`nose2`).
 - [ ] There are no linting errors (`python setup.py lint`).
 - [ ] The changes don't break existing features.
 - [ ] Check that there are no confidential files like `.env` included.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.9'
+        python-version: '3.10'
 
     - name: Install Pip
       run:  python -m pip install --upgrade pip

--- a/.github/workflows/early-warning.yml
+++ b/.github/workflows/early-warning.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.9'
+          python-version: '3.10'
 
       - name: Setup environment
         run: pip install -r requirements.txt

--- a/.github/workflows/python-non-master.yml
+++ b/.github/workflows/python-non-master.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
 
     steps:
     - uses: actions/checkout@v2
@@ -36,4 +36,4 @@ jobs:
         pylint howdoi *.py --rcfile=.pylintrc
     - name: Test with nose
       run: |
-        nosetests
+        nose2

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
 
     steps:
     - uses: actions/checkout@v2
@@ -32,4 +32,4 @@ jobs:
         pylint howdoi *.py --rcfile=.pylintrc
     - name: Test with nose
       run: |
-        nosetests
+        nose2

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,4 +1,4 @@
-# Contains common requirements 
+# Contains common requirements
 Pygments>=2.3.1
 argparse==1.4.0
 cssselect==1.1.0
@@ -8,4 +8,3 @@ requests==2.24.0
 cachelib==0.1.1
 appdirs==1.4.4
 keep==2.9
-pathlib==1.0.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,6 @@
 # Contains development specific requirements and imports common requirements
 flake8==3.9.2
-nose==1.3.7
+nose2==0.6.0
 pylint==2.11.1
 pre-commit==2.13.0
 twine==3.4.1

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Documentation",
     ],
     keywords='howdoi help console command line answer',


### PR DESCRIPTION
Fixes https://github.com/gleitz/howdoi/issues/447

Also include Python 3.10 as the default and supported version.
Also update `nose` to `nose2` to handle an issue with Python 3.10. Perhaps We should switch to Pytest in the future.