### PR TITLE
Add encoding utf-8 while package setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def read(*names):
         for extension in ('.txt', '.md'):
             filename = name + extension
             if Path(filename).is_file():
-                with open(filename) as in_file:  # pylint: disable=unspecified-encoding
+                with open(filename, encoding='utf-8') as in_file:  # pylint: disable=unspecified-encoding
                     value = in_file.read()
                 break
         values[name] = value


### PR DESCRIPTION
## Description:

- Tasks solved
In Korean, Japanese windows(in my case Korean windows 10) having code  page cp949 or else, its installation failed. So I added UTF-8 encoding arguments while file opening to fix it. 
![encoding_error](https://user-images.githubusercontent.com/83936830/158172165-1b121241-8866-4a31-8047-755b9118c426.png)

## Pull Request type:
- Bug fixes
- New feature
- Improvement
- Refactoring
- Documentation update
- Security fix

## How to test:

Please provide detailed instructions for testing your changes locally, including expected response/behavior.

## Pull Request checklist:

- [x] Read the [contributing_to_howdoi.md](https://github.com/gleitz/howdoi/blob/master/docs/contributing_to_howdoi.md)
- [x] Attach screenshots of expected behavior.
- [x] The changes pass tests locally (`nose2`).
- [ ] There are no linting errors (`python setup.py lint`).
- [ ] The changes don't break existing features.
- [ ] Check that there are no confidential files like `.env` included.
- [ ] Request review from the maintainers.
- [ ] For bug fixes or changes to directory structure, make sure docs are updated.

## Known bugs (if any):

If there are bugs in your current changes you can still open the PR and mention the bugs you found. Propose further changes that can help fix bugs in your current changes.
