### PR TITLE
rough draft: attempt to make `keep` an extra

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,8 +91,12 @@ setup(
     url='https://github.com/gleitz/howdoi',
     license='MIT',
     packages=find_packages(),
+    extras_require={
+        "keep": ["keep],
+    },
     entry_points={
         'console_scripts': [
+            'keep = keep.cli:cli [keep]'
             'howdoi = howdoi.howdoi:command_line_runner',
         ]
     },
@@ -104,7 +108,6 @@ setup(
         'requests',
         'cachelib',
         'appdirs',
-        'keep',
         'rich'
     ],
     cmdclass={


### PR DESCRIPTION
attempt to make `keep` an extra to put it on the PATH when installing via pipx/homebrew

For anyone who might have time to take up the mantle of keeping keep on the PATH here (see #425 for context):

I missed a quote. Let's pretend it was intentional to keep this rush-job from getting merged in ;) I have no experience with setuptools and unfortunately don't have more time to tinker- just stumbled across this potential solution and thought I should share



Of particular interest in #425 thread, last comment: as mentioned, consider use case where user opts not to install keep.

- Bug fixes

## How to test:

I _think_ you should be able to clone this branch, fix the quote, and [`pipx install .[keep]`](https://stackoverflow.com/questions/30239152/specify-extras-require-with-pip-install-e)

Not sure how to test w/ `brew`

@gleitz feel free to close if this just adds noise to your repo i wont be offended :)

Please provide detailed instructions for testing your changes locally, including expected response/behavior.

## Pull Request checklist:

- [ ] Read the [contributing_to_howdoi.md](https://github.com/gleitz/howdoi/blob/master/docs/contributing_to_howdoi.md)
- [ ] Attach screenshots of expected behavior.
- [ ] The changes pass tests locally (`nose2`).
- [ ] There are no linting errors (`python setup.py lint`).
- [ ] The changes don't break existing features.
- [ ] Check that there are no confidential files like `.env` included.
- [ ] Request review from the maintainers.
- [ ] For bug fixes or changes to directory structure, make sure docs are updated.

## Known bugs (if any):

If there are bugs in your current changes you can still open the PR and mention the bugs you found. Propose further changes that can help fix bugs in your current changes.
