### PR TITLE
docs: fix simple typo, ecapsulated -> encapsulated

### DIFF
--- a/extension/code-editor-integration/README.md
+++ b/extension/code-editor-integration/README.md
@@ -18,7 +18,7 @@ The Code Editor Integration plug-in is ran by calling the `runHowdoi` function w
     }
 
 The Object values:
-* question contains the user's query ecapsulated by a single line comment
+* question contains the user's query encapsulated by a single line comment
 * answer contains the three possible answers to the user's query 
 * link contains the three possible links to the answer encapsulated by a single line comment
 


### PR DESCRIPTION
There is a small typo in extension/code-editor-integration/README.md.

Should read `encapsulated` rather than `ecapsulated`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md